### PR TITLE
Fix blog fetching and remove missing asset references

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -144,9 +144,8 @@ export default function RootLayout({
         <div 
           className="fixed inset-0 -z-10 bg-zinc-400"
           style={{
-            backgroundImage: "url('/images/bg-pattern.jpg')",
-            backgroundSize: "cover",
-            backgroundPosition: "center",
+            backgroundImage:
+              'radial-gradient(circle at 20% 10%, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 55%), radial-gradient(circle at 80% 30%, rgba(255,255,255,0.18) 0%, rgba(255,255,255,0) 60%), linear-gradient(180deg, rgba(161,161,170,1) 0%, rgba(212,212,216,1) 100%)',
           }}
           aria-hidden="true"
         />

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -56,7 +56,7 @@ export interface Post {
   }
   author: number
   featured_media: number
-  categories: number[]
+  categories: Category[] | number[]
   tags: Tag[] | number[]
   _embedded?: {
     author?: Array<{

--- a/public/sw.js
+++ b/public/sw.js
@@ -15,8 +15,6 @@ const STATIC_ASSETS = [
   '/aris.png',
   '/case-1.png',
   '/favicon.ico',
-  '/fonts/GeistVF.woff',
-  '/fonts/GeistMonoVF.woff',
 ];
 
 // Cache strategies


### PR DESCRIPTION
Stop service worker precaching missing font files, remove missing bg-pattern image usage, and normalize WP API base URL so blog loads on Vercel regardless of whether NEXT_PUBLIC_WP_API_URL includes /wp-json.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blog loading on Vercel by normalizing the WordPress API base URL and centralizing fetch logic. Removes references to missing assets to prevent 404s and visual glitches.

- **Bug Fixes**
  - Normalize NEXT_PUBLIC_WP_API_URL to include /wp-json when missing.
  - Blog page uses getPosts/getAllTags; safely resolves category/tag IDs vs objects.
  - Stop service worker from precaching missing font files.
  - Replace missing bg-pattern.jpg with a CSS gradient background.

<sup>Written for commit 9aee2063078bc2e1a1cd0fec94729d0f7c5644ad. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

