### PR TITLE
Refactor BlogPost Page to Await Params for Improved Data Handling

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -21,13 +21,13 @@ import { getPost, getPosts } from '@/lib/wordpress'
 export const revalidate = 3600 // Revalidate every hour
 
 interface BlogPostPageProps {
-  params: {
+  params: Promise<{
     slug: string
-  }
+  }>
 }
 
 export async function generateMetadata({ params }: BlogPostPageProps): Promise<Metadata> {
-  const { slug } = params
+  const { slug } = await params
   try {
     const post = await getPost(slug)
     if (!post) {
@@ -188,7 +188,7 @@ function transformTheImage(content: string): string {
 }
 
 export default async function BlogPost({ params }: BlogPostPageProps) {
-  const { slug } = params
+  const { slug } = await params
   
   try {
     const post = await getPost(slug)


### PR DESCRIPTION
Updated the BlogPostPageProps interface to use a Promise for params, ensuring that the slug is correctly awaited before fetching the post. This change enhances the reliability of data retrieval and prevents potential issues with undefined parameters during rendering.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Await blog post route params so the slug is resolved before fetching content and metadata. Prevents undefined slug errors and stabilizes rendering.

- **Bug Fixes**
  - Updated BlogPostPageProps to use a Promise and awaited params in generateMetadata and the page component.

<sup>Written for commit d2fe5375243652cd6d000ad043247ae9e45de681. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

