### PR TITLE
Add 301 redirects for legacy /about-me and /contact-us URLs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -77,6 +77,28 @@ const nextConfig = {
   output: 'standalone',
   compress: true,
   generateEtags: true,
+  redirects: async () => [
+    {
+      source: '/about-me',
+      destination: '/about',
+      permanent: true,
+    },
+    {
+      source: '/about-me/',
+      destination: '/about',
+      permanent: true,
+    },
+    {
+      source: '/contact-us',
+      destination: '/contact',
+      permanent: true,
+    },
+    {
+      source: '/contact-us/',
+      destination: '/contact',
+      permanent: true,
+    },
+  ],
   headers: async () => {
     // IMPORTANT: Never set long-lived cache headers in dev.
     // It will cause the browser to cache `/_next/static/*` bundles and trigger hydration mismatches


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds permanent (301) redirects in `next.config.js` for two legacy public URLs that currently 404:

| Legacy URL | Redirects to |
|---|---|
| `/about-me` and `/about-me/` | `/about` |
| `/contact-us` and `/contact-us/` | `/contact` |

## Changes

- Added a `redirects` async function to `next.config.js` (no `vercel.json` in this repo).
- Grepped the codebase for hardcoded `/about-me` and `/contact-us` links — none found, so no in-app link updates were needed.

## Verification

- `pnpm lint` — 0 errors (13 existing warnings)
- `pnpm build` — succeeded

## Notes

Minimal, config-only change. No dependency updates or content changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95435272-1a6c-4fa8-8462-19d8a3621a1b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95435272-1a6c-4fa8-8462-19d8a3621a1b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add permanent (301) redirects in `next.config.js` mapping `/about-me` → `/about` and `/contact-us` → `/contact`, covering both trailing-slash and non-trailing-slash variants. Fixes 404s and preserves SEO/link equity for legacy URLs.

<sup>Written for commit b6e7ef568d32090e6dee418230d5fa0433025b07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/madebyaris/madebyaris.com/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

