### PR TITLE
Release: Next.js global hire page

### DIFF
--- a/app/services/nextjs-development/page.tsx
+++ b/app/services/nextjs-development/page.tsx
@@ -1,108 +1,161 @@
 import type { Metadata } from 'next'
-import { Code2, ArrowRight, ArrowUpRight, Rocket, Globe, Zap, Search, Building, Users, Trophy } from 'lucide-react'
+import {
+  Code2,
+  ArrowRight,
+  ArrowUpRight,
+  Rocket,
+  Globe,
+  Zap,
+  Search,
+  Building,
+  Users,
+  Briefcase,
+  Sparkles,
+  Calendar,
+} from 'lucide-react'
 import Link from 'next/link'
+import { buildPageMetadata } from '@/lib/seo'
 
-// Structured Data
 const structuredData = {
-  "@context": "https://schema.org",
-  "@type": "WebPage",
-  "@id": "https://madebyaris.com/services/nextjs-development/#webpage",
-  "name": "Next.js Development | React & TypeScript Solutions",
-  "description": "Crafting high-performance web applications with Next.js, React, and TypeScript.",
-  "url": "https://madebyaris.com/services/nextjs-development"
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  '@id': 'https://madebyaris.com/services/nextjs-development/#webpage',
+  name: 'Hire a Next.js Developer | Remote Full-Stack | Aris Setiawan',
+  description:
+    'Hire a Next.js developer for product builds, migrations, and performance work. Remote-friendly. 13+ years. Cursor Ambassador — AI-accelerated delivery.',
+  url: 'https://madebyaris.com/services/nextjs-development',
 }
 
 export async function generateMetadata(): Promise<Metadata> {
+  const metadata = buildPageMetadata({
+    title: 'Hire a Next.js Developer | Remote Full-Stack | Aris Setiawan',
+    description:
+      'Hire a Next.js developer for product builds, migrations, and performance work. Remote-friendly. 13+ years. Cursor Ambassador — AI-accelerated delivery.',
+    path: '/services/nextjs-development',
+  })
+
   return {
-    title: 'Next.js Development Services | Modern Web Applications',
-    description: 'Expert Next.js development services for modern web applications. Full-stack solutions with React, TypeScript, and enterprise-grade architecture.',
+    ...metadata,
     keywords: [
-      'Next.js Development',
-      'React Development',
-      'TypeScript Development',
-      'Full Stack Development',
-      'Enterprise Web Apps',
-      'Modern Web Development',
-      'Next.js Expert'
+      'Hire Next.js Developer',
+      'Next.js Developer',
+      'Remote Next.js Developer',
+      'Next.js Full-Stack Developer',
+      'Next.js Migration',
+      'Next.js Performance',
+      'Headless WordPress Next.js',
+      'App Router Developer',
     ],
-    openGraph: {
-      title: 'Next.js Development Services | Modern Web Applications',
-      description: 'Expert Next.js development services for modern web applications.',
-      type: 'website',
-      locale: 'en_US',
-    },
-    alternates: {
-      canonical: 'https://madebyaris.com/services/nextjs-development'
-    }
   }
 }
 
-const features = [
+const helpWith = [
   {
-    title: 'Modern Development',
-    description: 'Building fast, modern web applications using the latest Next.js features.',
-    icon: Code2,
-  },
-  {
-    title: 'Performance Focus',
-    description: 'Optimized for speed with server-side rendering and static generation.',
+    title: 'New Next.js products',
+    description: 'App Router, TypeScript, and APIs — from MVP to production-ready apps.',
     icon: Rocket,
   },
   {
-    title: 'Global Deployment',
-    description: 'Seamless deployment to edge networks for optimal performance.',
+    title: 'Migrations',
+    description: 'WordPress or legacy React → Next.js without losing SEO or content workflows.',
     icon: Globe,
   },
   {
-    title: 'API Integration',
-    description: 'Building robust API routes and integrating with external services.',
+    title: 'Performance & SEO',
+    description: 'SSR/SSG, Core Web Vitals, and metadata that search engines and users notice.',
     icon: Zap,
+  },
+  {
+    title: 'Headless setups',
+    description: 'Next.js + WordPress or other CMS when content teams need familiar tools.',
+    icon: Code2,
+  },
+  {
+    title: 'Ongoing product engineering',
+    description: 'Features, refactors, and code reviews on an existing codebase.',
+    icon: Briefcase,
   },
 ]
 
-const benefits = [
-  'Fast Loading',
-  'SEO Optimized',
-  'Type Safe',
-  'Modern Stack',
-  'Edge Ready',
-  'API Routes',
-  'SSR Support',
-  'Easy Scaling',
+const engagementOptions = [
+  {
+    title: 'Fixed-scope build',
+    description: 'Landing page, marketing site, or MVP slice with a clear deliverable.',
+  },
+  {
+    title: 'Product sprint',
+    description: '2–4 weeks of focused delivery on a defined set of features or improvements.',
+  },
+  {
+    title: 'Retainer',
+    description: 'Ongoing Next.js engineering support after launch or between releases.',
+  },
 ]
 
 const processSteps = [
-  { title: 'Requirements Analysis', description: 'Understanding your needs and planning architecture.' },
-  { title: 'Development', description: 'Building with clean, efficient, maintainable code.' },
-  { title: 'Testing & Optimization', description: 'Comprehensive testing and performance tuning.' },
-  { title: 'Deployment & Support', description: 'Setting up CI/CD and ongoing maintenance.' },
+  { title: 'Scope', description: 'Goals, constraints, and success criteria.' },
+  { title: 'Build', description: 'Weekly demos — no black box.' },
+  { title: 'Harden', description: 'Performance, SEO basics, and handoff docs.' },
+  { title: 'Support', description: 'Optional retainers after launch.' },
+]
+
+const stackItems = [
+  'Next.js',
+  'React',
+  'TypeScript',
+  'Tailwind',
+  'Node',
+  'Prisma',
+  'PostgreSQL',
+  'Vercel',
+  'WordPress / headless',
 ]
 
 const specializedServices = [
   {
     title: 'Vercel Deployment',
-    description: 'Expert Vercel deployment with edge functions, analytics, and enterprise infrastructure.',
+    description: 'Edge functions, analytics, and production deployment on Vercel.',
     icon: Rocket,
-    href: '/services/nextjs-development/vercel'
+    href: '/services/nextjs-development/vercel',
   },
   {
-    title: 'Next.js Indonesia',
-    description: 'Specialized Next.js services for the Indonesian market with local support.',
-    icon: Globe,
-    href: '/services/nextjs-development/nextjs-indonesia'
-  },
-  {
-    title: 'Next.js SEO Services',
-    description: 'Comprehensive SEO optimization for Next.js with SSR and metadata optimization.',
+    title: 'Next.js SEO',
+    description: 'SSR, metadata, and Core Web Vitals optimization for Next.js sites.',
     icon: Search,
-    href: '/services/nextjs-development/nextjs-seo'
+    href: '/services/nextjs-development/nextjs-seo',
   },
   {
-    title: 'Agency Services Indonesia',
-    description: 'Full-service Next.js agency for Indonesian enterprises from planning to deployment.',
+    title: 'Indonesia (Bahasa)',
+    description: 'Bahasa Indonesia pages and local support for clients who prefer it.',
+    icon: Globe,
+    href: '/services/nextjs-development/nextjs-indonesia',
+  },
+  {
+    title: 'Indonesia · Specialist',
+    description: 'Solo specialist support for Indonesian teams — not a large agency bench.',
     icon: Building,
-    href: '/services/nextjs-development/agency-indonesia'
-  }
+    href: '/services/nextjs-development/agency-indonesia',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Do you work with US / EU / remote teams?',
+    answer: 'Yes. Async-first, with overlap hours by agreement.',
+  },
+  {
+    question: 'Can you join an existing Next.js codebase?',
+    answer: 'Yes — features, refactors, and cleanup.',
+  },
+  {
+    question: 'WordPress too?',
+    answer: 'Yes, especially headless WordPress + Next.js.',
+  },
+  {
+    question: 'Indonesia-only?',
+    answer:
+      'No. Based in Indonesia, clients can be anywhere. Local ID pages stay available if you need Bahasa.',
+  },
 ]
 
 export default function NextjsDevelopmentPage() {
@@ -112,178 +165,196 @@ export default function NextjsDevelopmentPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
       />
-      
+
       {/* Hero Section */}
       <section className="text-center pt-8 pb-16">
-        {/* Badge */}
-        <div 
+        <div
           className="inline-flex bg-white/60 rounded-full mb-8 py-1.5 pr-4 pl-3 shadow-sm backdrop-blur-sm items-center gap-2"
           style={{
             position: 'relative',
             // @ts-expect-error CSS custom properties
             '--border-gradient': 'linear-gradient(180deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0))',
-            '--border-radius-before': '9999px'
+            '--border-radius-before': '9999px',
           }}
         >
           <Code2 className="w-4 h-4 text-orange-500" />
-          <span className="text-xs font-semibold tracking-wider uppercase text-zinc-600">Next.js Expert</span>
+          <span className="text-xs font-semibold tracking-wider uppercase text-zinc-600">
+            Next.js · Remote · Available for hire
+          </span>
         </div>
 
-        {/* Title */}
         <h1 className="leading-[0.95] lg:text-[4rem] text-4xl font-medium text-zinc-900 tracking-tighter mb-6">
-          Next.js
-          <span className="block gradient-text font-light">Development</span>
-          <span className="block">Services</span>
+          Hire a Next.js developer
+          <span className="block gradient-text font-light">who ships</span>
         </h1>
 
-        {/* Description */}
         <p className="text-base md:text-lg text-zinc-500 max-w-2xl mx-auto mb-10 leading-relaxed font-medium">
-          Modern web applications built with Next.js. Optimized for performance, 
-          SEO, and exceptional user experience.
+          I&apos;m Aris Setiawan. I build production Next.js apps for startups and teams worldwide
+          — clean architecture, fast pages, and practical AI workflows so we move quicker without
+          messy code.
         </p>
 
-        {/* CTA Buttons */}
-        <div className="flex flex-wrap justify-center gap-3">
-          <Link 
+        <div className="flex flex-wrap justify-center gap-3 mb-8">
+          <Link
             href="/contact"
             className="btn-primary hover:scale-[1.02] transition-all inline-flex group shadow-zinc-900/10 hover:shadow-2xl hover:shadow-zinc-900/20 hover:-translate-y-0.5 text-sm font-medium text-zinc-900 rounded-full py-3 px-6 gap-3 items-center"
           >
-            <span className="text-sm font-medium tracking-tight">Start Your Project</span>
+            <span className="text-sm font-medium tracking-tight">Hire me to build</span>
             <ArrowUpRight className="w-4 h-4 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform" />
           </Link>
-          <Link 
+          <Link
             href="/projects"
             className="btn-secondary hover:bg-zinc-50 transition-all flex text-sm font-medium rounded-full py-3 px-6 gap-2 items-center"
             style={{
-              boxShadow: '0 18px 35px rgba(31, 41, 55, 0.15), 0 0 0 1px rgba(209, 213, 219, 0.3)',
+              boxShadow:
+                '0 18px 35px rgba(31, 41, 55, 0.15), 0 0 0 1px rgba(209, 213, 219, 0.3)',
               position: 'relative',
               // @ts-expect-error CSS custom properties
-              '--border-gradient': 'linear-gradient(180deg, rgba(255, 255, 255, 0.8), rgba(0, 0, 0, 0.2), rgba(255, 255, 255, 0.8))',
-              '--border-radius-before': '9999px'
+              '--border-gradient':
+                'linear-gradient(180deg, rgba(255, 255, 255, 0.8), rgba(0, 0, 0, 0.2), rgba(255, 255, 255, 0.8))',
+              '--border-radius-before': '9999px',
             }}
           >
-            <span className="text-sm font-medium text-black/60 tracking-tight">View Portfolio</span>
+            <span className="text-sm font-medium text-black/60 tracking-tight">
+              See selected work
+            </span>
             <ArrowRight className="w-4 h-4 text-zinc-500" />
           </Link>
         </div>
+
+        <p className="text-xs md:text-sm text-zinc-500 font-medium max-w-3xl mx-auto leading-relaxed">
+          13+ years · Cursor Ambassador Indonesia · MiniMax Dev Community Expert · Remote across
+          US, EU, Asia & Middle East
+        </p>
       </section>
 
-      {/* Separator */}
       <div className="w-full h-px bg-linear-to-r from-transparent via-zinc-200 to-transparent mb-16 opacity-60" />
 
-      {/* Key Features Section */}
+      {/* What I help with */}
       <section className="mb-16">
         <div className="text-center mb-10">
-          <div 
+          <div
             className="inline-flex bg-white/60 rounded-full mb-4 py-1.5 pr-4 pl-3 shadow-sm backdrop-blur-sm items-center gap-2"
             style={{
               position: 'relative',
               // @ts-expect-error CSS custom properties
               '--border-gradient': 'linear-gradient(180deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0))',
-              '--border-radius-before': '9999px'
+              '--border-radius-before': '9999px',
             }}
           >
-            <Zap className="w-4 h-4 text-orange-500" />
-            <span className="text-xs font-semibold tracking-wider uppercase text-zinc-600">Key Features</span>
+            <Briefcase className="w-4 h-4 text-orange-500" />
+            <span className="text-xs font-semibold tracking-wider uppercase text-zinc-600">
+              Services
+            </span>
           </div>
           <h2 className="text-2xl md:text-3xl font-medium text-zinc-900 tracking-tighter mb-3">
-            What Makes Next.js <span className="gradient-text">Special</span>
+            What I <span className="gradient-text">help with</span>
           </h2>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-          {features.map((feature) => (
-            <div 
-              key={feature.title}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {helpWith.map((item) => (
+            <div
+              key={item.title}
               className="bg-white/80 backdrop-blur-sm rounded-2xl p-5 shadow-sm hover:shadow-lg transition-all group"
             >
               <div className="p-3 bg-zinc-100 rounded-xl w-fit mb-4 group-hover:bg-orange-100 transition-colors">
-                <feature.icon className="w-5 h-5 text-zinc-600 group-hover:text-orange-500 transition-colors" />
+                <item.icon className="w-5 h-5 text-zinc-600 group-hover:text-orange-500 transition-colors" />
               </div>
-              <h3 className="font-semibold text-zinc-900 mb-2">{feature.title}</h3>
-              <p className="text-sm text-zinc-500 leading-relaxed">{feature.description}</p>
+              <h3 className="font-semibold text-zinc-900 mb-2">{item.title}</h3>
+              <p className="text-sm text-zinc-500 leading-relaxed">{item.description}</p>
             </div>
           ))}
         </div>
       </section>
 
-      {/* Separator */}
       <div className="w-full h-px bg-linear-to-r from-transparent via-zinc-200 to-transparent mb-16 opacity-60" />
 
-      {/* Benefits Section */}
+      {/* How this is different */}
       <section className="mb-16">
         <div className="text-center mb-10">
-          <div 
+          <div
             className="inline-flex bg-white/60 rounded-full mb-4 py-1.5 pr-4 pl-3 shadow-sm backdrop-blur-sm items-center gap-2"
             style={{
               position: 'relative',
               // @ts-expect-error CSS custom properties
               '--border-gradient': 'linear-gradient(180deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0))',
-              '--border-radius-before': '9999px'
+              '--border-radius-before': '9999px',
             }}
           >
-            <Trophy className="w-4 h-4 text-orange-500" />
-            <span className="text-xs font-semibold tracking-wider uppercase text-zinc-600">Advantages</span>
+            <Sparkles className="w-4 h-4 text-orange-500" />
+            <span className="text-xs font-semibold tracking-wider uppercase text-zinc-600">
+              Approach
+            </span>
           </div>
-          <h2 className="text-2xl md:text-3xl font-medium text-zinc-900 tracking-tighter">
-            Benefits of Next.js <span className="gradient-text">Development</span>
+          <h2 className="text-2xl md:text-3xl font-medium text-zinc-900 tracking-tighter mb-3">
+            How this is <span className="gradient-text">different</span>
           </h2>
         </div>
 
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-          {benefits.map((benefit) => (
-            <div 
-              key={benefit}
-              className="p-4 bg-white/80 backdrop-blur-sm rounded-xl text-center text-sm font-medium text-zinc-700 hover:bg-orange-50 hover:text-orange-600 transition-colors"
-            >
-              {benefit}
-            </div>
-          ))}
+        <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 md:p-8 shadow-sm max-w-3xl mx-auto">
+          <p className="text-base md:text-lg text-zinc-600 leading-relaxed font-medium text-center">
+            Most &ldquo;Next.js agencies&rdquo; sell a process deck. I sell outcomes: a working
+            product, clear communication, and a codebase you can maintain. I also use Cursor and
+            modern AI tooling day-to-day — not as a gimmick, as a way to ship carefully and faster.
+          </p>
         </div>
       </section>
 
-      {/* Separator */}
       <div className="w-full h-px bg-linear-to-r from-transparent via-zinc-200 to-transparent mb-16 opacity-60" />
 
-      {/* Process Section */}
+      {/* Engagement options */}
       <section className="mb-16">
         <div className="text-center mb-10">
+          <div
+            className="inline-flex bg-white/60 rounded-full mb-4 py-1.5 pr-4 pl-3 shadow-sm backdrop-blur-sm items-center gap-2"
+            style={{
+              position: 'relative',
+              // @ts-expect-error CSS custom properties
+              '--border-gradient': 'linear-gradient(180deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0))',
+              '--border-radius-before': '9999px',
+            }}
+          >
+            <Calendar className="w-4 h-4 text-orange-500" />
+            <span className="text-xs font-semibold tracking-wider uppercase text-zinc-600">
+              Engagements
+            </span>
+          </div>
           <h2 className="text-2xl md:text-3xl font-medium text-zinc-900 tracking-tighter mb-3">
-            Development <span className="gradient-text">Process</span>
+            Engagement <span className="gradient-text">options</span>
           </h2>
         </div>
-        
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          {processSteps.map((step, index) => (
-            <div 
-              key={step.title}
-              className="bg-zinc-50 rounded-2xl p-5 text-center"
-            >
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {engagementOptions.map((option, index) => (
+            <div key={option.title} className="bg-zinc-50 rounded-2xl p-5 text-center">
               <div className="w-10 h-10 rounded-full bg-orange-100 text-orange-500 font-bold text-lg flex items-center justify-center mx-auto mb-3">
                 {index + 1}
               </div>
-              <h3 className="font-semibold text-zinc-900 mb-1">{step.title}</h3>
-              <p className="text-sm text-zinc-500">{step.description}</p>
+              <h3 className="font-semibold text-zinc-900 mb-1">{option.title}</h3>
+              <p className="text-sm text-zinc-500">{option.description}</p>
             </div>
           ))}
         </div>
       </section>
 
-      {/* Separator */}
       <div className="w-full h-px bg-linear-to-r from-transparent via-zinc-200 to-transparent mb-16 opacity-60" />
 
-      {/* Technologies Section */}
+      {/* Stack */}
       <section className="mb-16">
         <div className="text-center mb-10">
           <h2 className="text-2xl md:text-3xl font-medium text-zinc-900 tracking-tighter mb-3">
-            Tech <span className="gradient-text">Stack</span>
+            Stack I use <span className="gradient-text">most</span>
           </h2>
+          <p className="text-sm text-zinc-500 max-w-2xl mx-auto font-medium">
+            WordPress/headless when content teams need it.
+          </p>
         </div>
 
         <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6">
-          <div className="grid grid-cols-3 md:grid-cols-6 gap-3">
-            {['Next.js', 'React', 'TypeScript', 'Tailwind CSS', 'Node.js', 'Prisma', 'tRPC', 'GraphQL', 'REST API', 'MongoDB', 'PostgreSQL', 'Vercel'].map((tech) => (
-              <div 
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
+            {stackItems.map((tech) => (
+              <div
                 key={tech}
                 className="p-3 bg-zinc-50 rounded-xl text-center text-xs font-medium text-zinc-600 hover:bg-orange-50 hover:text-orange-600 transition-colors"
               >
@@ -294,26 +365,50 @@ export default function NextjsDevelopmentPage() {
         </div>
       </section>
 
-      {/* Separator */}
+      <div className="w-full h-px bg-linear-to-r from-transparent via-zinc-200 to-transparent mb-16 opacity-60" />
+
+      {/* Process */}
+      <section className="mb-16">
+        <div className="text-center mb-10">
+          <h2 className="text-2xl md:text-3xl font-medium text-zinc-900 tracking-tighter mb-3">
+            <span className="gradient-text">Process</span>
+          </h2>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          {processSteps.map((step, index) => (
+            <div key={step.title} className="bg-zinc-50 rounded-2xl p-5 text-center">
+              <div className="w-10 h-10 rounded-full bg-orange-100 text-orange-500 font-bold text-lg flex items-center justify-center mx-auto mb-3">
+                {index + 1}
+              </div>
+              <h3 className="font-semibold text-zinc-900 mb-1">{step.title}</h3>
+              <p className="text-sm text-zinc-500">{step.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
       <div className="w-full h-px bg-linear-to-r from-transparent via-zinc-200 to-transparent mb-16 opacity-60" />
 
       {/* Specialized Services */}
       <section className="mb-16">
         <div className="text-center mb-10">
-          <div 
+          <div
             className="inline-flex bg-white/60 rounded-full mb-4 py-1.5 pr-4 pl-3 shadow-sm backdrop-blur-sm items-center gap-2"
             style={{
               position: 'relative',
               // @ts-expect-error CSS custom properties
               '--border-gradient': 'linear-gradient(180deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0))',
-              '--border-radius-before': '9999px'
+              '--border-radius-before': '9999px',
             }}
           >
             <Building className="w-4 h-4 text-orange-500" />
-            <span className="text-xs font-semibold tracking-wider uppercase text-zinc-600">Specialized Services</span>
+            <span className="text-xs font-semibold tracking-wider uppercase text-zinc-600">
+              Specialized
+            </span>
           </div>
           <h2 className="text-2xl md:text-3xl font-medium text-zinc-900 tracking-tighter">
-            Tailored <span className="gradient-text">Solutions</span>
+            Tailored <span className="gradient-text">solutions</span>
           </h2>
         </div>
 
@@ -329,9 +424,7 @@ export default function NextjsDevelopmentPage() {
                     <h3 className="text-lg font-semibold text-zinc-900 mb-1 group-hover:text-orange-500 transition-colors">
                       {service.title}
                     </h3>
-                    <p className="text-sm text-zinc-500 leading-relaxed">
-                      {service.description}
-                    </p>
+                    <p className="text-sm text-zinc-500 leading-relaxed">{service.description}</p>
                   </div>
                   <ArrowUpRight className="w-5 h-5 text-zinc-400 opacity-0 group-hover:opacity-100 transition-opacity" />
                 </div>
@@ -341,52 +434,31 @@ export default function NextjsDevelopmentPage() {
         </div>
       </section>
 
-      {/* Separator */}
       <div className="w-full h-px bg-linear-to-r from-transparent via-zinc-200 to-transparent mb-16 opacity-60" />
 
       {/* FAQ Section */}
       <section className="mb-16">
         <div className="text-center mb-10">
-          <div 
+          <div
             className="inline-flex bg-white/60 rounded-full mb-4 py-1.5 pr-4 pl-3 shadow-sm backdrop-blur-sm items-center gap-2"
             style={{
               position: 'relative',
               // @ts-expect-error CSS custom properties
               '--border-gradient': 'linear-gradient(180deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0))',
-              '--border-radius-before': '9999px'
+              '--border-radius-before': '9999px',
             }}
           >
             <Users className="w-4 h-4 text-orange-500" />
             <span className="text-xs font-semibold tracking-wider uppercase text-zinc-600">FAQ</span>
           </div>
           <h2 className="text-2xl md:text-3xl font-medium text-zinc-900 tracking-tighter">
-            Common <span className="gradient-text">Questions</span>
+            Common <span className="gradient-text">questions</span>
           </h2>
         </div>
 
         <div className="space-y-3">
-          {[
-            {
-              question: "What is Next.js and why should I use it?",
-              answer: "Next.js is a React framework that enables server-side rendering, static generation, and performance optimizations. It's ideal for SEO, fast loading, and modern development."
-            },
-            {
-              question: "How long does it take to develop a Next.js application?",
-              answer: "Most small to medium applications take 4-12 weeks. Enterprise applications may take longer depending on complexity and integrations."
-            },
-            {
-              question: "Do you work with existing codebases?",
-              answer: "Yes! I work with both new projects and existing codebases, including migrations from other frameworks to Next.js."
-            },
-            {
-              question: "What makes your services different?",
-              answer: "I combine technical expertise with business focus, prioritizing performance, maintainability, and user experience while meeting your specific goals."
-            }
-          ].map((faq, index) => (
-            <div 
-              key={index}
-              className="bg-white/80 backdrop-blur-sm rounded-xl p-5"
-            >
+          {faqs.map((faq) => (
+            <div key={faq.question} className="bg-white/80 backdrop-blur-sm rounded-xl p-5">
               <h3 className="font-semibold text-zinc-900 mb-2">{faq.question}</h3>
               <p className="text-sm text-zinc-500 leading-relaxed">{faq.answer}</p>
             </div>
@@ -394,31 +466,38 @@ export default function NextjsDevelopmentPage() {
         </div>
       </section>
 
-      {/* CTA Section */}
+      {/* Closing CTA */}
       <section className="overflow-hidden min-h-[400px] shadow-zinc-900/30 bg-zinc-900 rounded-4xl relative shadow-2xl mb-8">
-        <div 
-          className="absolute inset-0 opacity-10" 
+        <div
+          className="absolute inset-0 opacity-10"
           style={{
-            backgroundImage: 'linear-gradient(rgba(255,255,255,.05) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.05) 1px, transparent 1px)',
-            backgroundSize: '40px 40px'
+            backgroundImage:
+              'linear-gradient(rgba(255,255,255,.05) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.05) 1px, transparent 1px)',
+            backgroundSize: '40px 40px',
           }}
         />
 
         <div className="flex flex-col items-center justify-center text-center p-8 md:p-12 lg:p-16 min-h-[400px] relative">
           <h2 className="md:text-4xl lg:text-5xl leading-tight text-3xl font-normal text-white tracking-tight mb-6 max-w-2xl">
-            Ready to Build Your Next.js Project?
+            Need a Next.js developer for your next build?
           </h2>
-          <p className="text-zinc-400 mb-8 max-w-lg font-medium">
-            Let&apos;s discuss how Next.js can help you build a faster, more efficient web application.
-          </p>
 
-          <Link 
-            href="/contact"
-            className="group flex items-center gap-3 bg-white hover:bg-zinc-100 transition-all text-zinc-900 text-sm font-medium rounded-full px-6 py-3 shadow-lg hover:shadow-xl hover:-translate-y-0.5"
-          >
-            <span>Start Your Project</span>
-            <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
-          </Link>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/contact"
+              className="group flex items-center gap-3 bg-white hover:bg-zinc-100 transition-all text-zinc-900 text-sm font-medium rounded-full px-6 py-3 shadow-lg hover:shadow-xl hover:-translate-y-0.5"
+            >
+              <span>Start a project</span>
+              <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
+            </Link>
+            <Link
+              href="/services/nextjs-development/nextjs-indonesia"
+              className="group flex items-center gap-3 bg-zinc-800 hover:bg-zinc-700 transition-all text-white text-sm font-medium rounded-full px-6 py-3 border border-zinc-700 hover:-translate-y-0.5"
+            >
+              <span>Indonesia / Bahasa clients</span>
+              <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
+            </Link>
+          </div>
         </div>
       </section>
     </>


### PR DESCRIPTION
## Summary
Promote develop → main.

Includes PR #64 — rewrite `/services/nextjs-development` for global hire intent (SEO + messaging).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promote develop → main. Rewrite `/services/nextjs-development` to position Aris as a global, remote Next.js hire and improve SEO and conversions.

- **New Features**
  - Updated SEO: new title/description/keywords, structured data, and centralized metadata via `buildPageMetadata`.
  - Hiring-focused copy: new hero, badges, and CTAs; clear note on global remote availability.
  - Restructured content: services (builds, migrations, performance/SEO, headless, ongoing work), engagement options (fixed-scope, sprint, retainer), process, and stack.
  - Specialized services: highlight Vercel deployment, Next.js SEO, and Indonesia (Bahasa) options; reframed from agency to solo specialist.
  - Refreshed FAQ and closing CTA, including a direct link for Indonesia/Bahasa clients.

<sup>Written for commit 1fa0236c5464e70aa6be07e7f5f3f401ef18f283. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/madebyaris/madebyaris.com/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

