### PR TITLE
Release: fix Next.js page title duplication

### DIFF
--- a/app/services/nextjs-development/page.tsx
+++ b/app/services/nextjs-development/page.tsx
@@ -20,7 +20,7 @@ const structuredData = {
   '@context': 'https://schema.org',
   '@type': 'WebPage',
   '@id': 'https://madebyaris.com/services/nextjs-development/#webpage',
-  name: 'Hire a Next.js Developer | Remote Full-Stack | Aris Setiawan',
+  name: 'Hire a Next.js Developer | Remote Full-Stack',
   description:
     'Hire a Next.js developer for product builds, migrations, and performance work. Remote-friendly. 13+ years. Cursor Ambassador — AI-accelerated delivery.',
   url: 'https://madebyaris.com/services/nextjs-development',
@@ -28,7 +28,7 @@ const structuredData = {
 
 export async function generateMetadata(): Promise<Metadata> {
   const metadata = buildPageMetadata({
-    title: 'Hire a Next.js Developer | Remote Full-Stack | Aris Setiawan',
+    title: 'Hire a Next.js Developer | Remote Full-Stack',
     description:
       'Hire a Next.js developer for product builds, migrations, and performance work. Remote-friendly. 13+ years. Cursor Ambassador — AI-accelerated delivery.',
     path: '/services/nextjs-development',


### PR DESCRIPTION
## Summary
Promote develop → main.

Includes PR #66 — remove duplicated `| Aris Setiawan` from Next.js services page title (layout template already appends it).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix duplicated “| Aris Setiawan” in the Next.js Services page title. The page now relies on the root layout’s title template, updating both the metadata title and JSON-LD name to avoid double branding.

<sup>Written for commit f36023a5829a124ded96c0d7c693159653645c6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/madebyaris/madebyaris.com/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

