### PR TITLE
fix(seo): remove double brand suffix on Next.js services page title

### DIFF
--- a/app/services/nextjs-development/page.tsx
+++ b/app/services/nextjs-development/page.tsx
@@ -16,11 +16,13 @@ import {
 import Link from 'next/link'
 import { buildPageMetadata } from '@/lib/seo'
 
+const pageTitle = 'Hire a Next.js Developer | Remote Full-Stack | Aris Setiawan'
+
 const structuredData = {
   '@context': 'https://schema.org',
   '@type': 'WebPage',
   '@id': 'https://madebyaris.com/services/nextjs-development/#webpage',
-  name: 'Hire a Next.js Developer | Remote Full-Stack',
+  name: pageTitle,
   description:
     'Hire a Next.js developer for product builds, migrations, and performance work. Remote-friendly. 13+ years. Cursor Ambassador — AI-accelerated delivery.',
   url: 'https://madebyaris.com/services/nextjs-development',
@@ -36,6 +38,9 @@ export async function generateMetadata(): Promise<Metadata> {
 
   return {
     ...metadata,
+    title: { absolute: pageTitle },
+    openGraph: { ...metadata.openGraph, title: pageTitle },
+    twitter: { ...metadata.twitter, title: pageTitle },
     keywords: [
       'Hire Next.js Developer',
       'Next.js Developer',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After PR #66, the live `<title>` on `/services/nextjs-development` was:

`Hire a Next.js Developer | Remote Full-Stack | MadeByAris | Aris Setiawan`

Two separate layers were appending brand suffixes:

1. **`buildPageMetadata` → `@rankmyseo/core` `generateMeta`** — passes `siteName: siteConfig.shortName` (`MadeByAris`), so `generateMeta` produces a title like `Hire a Next.js Developer | Remote Full-Stack | MadeByAris`.
2. **Root `app/layout.tsx` `title.template`** — set to `"%s | Aris Setiawan"`, which wraps the page title and appends another suffix.

Together they produced the duplicated brand tail.

## Fix (page-level, minimal)

In `app/services/nextjs-development/page.tsx` `generateMetadata`:

- Define `pageTitle = 'Hire a Next.js Developer | Remote Full-Stack | Aris Setiawan'`
- After `buildPageMetadata(...)`, override with `title: { absolute: pageTitle }` so the layout template is skipped
- Override `openGraph.title` and `twitter.title` to the same string (the spread from `buildPageMetadata` would otherwise keep `MadeByAris` in social meta)
- Align JSON-LD `name` with `pageTitle` for consistency

No changes to root layout or `buildPageMetadata` (out of scope for this PR).

## Expected result

- Document title: `Hire a Next.js Developer | Remote Full-Stack | Aris Setiawan`
- OG/Twitter title: same string
- JSON-LD `name`: same string

## Verification

- `pnpm lint` — 0 errors (13 existing warnings)
- `pnpm build` — success
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20be0c51-701f-41d0-924f-4b98e4d4e01c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20be0c51-701f-41d0-924f-4b98e4d4e01c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the double brand suffix on the Next.js services page by setting an absolute title and syncing social/structured titles.

- **Bug Fixes**
  - Use `title: { absolute: 'Hire a Next.js Developer | Remote Full-Stack | Aris Setiawan' }` in `generateMetadata` to bypass the root `title.template`.
  - Align `openGraph.title`, `twitter.title`, and JSON‑LD `name` to the same string.

<sup>Written for commit 92f05da68bda531dd89e21ac76ba2731fb7c7b3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/madebyaris/madebyaris.com/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

