### PR TITLE
Release: absolute title for Next.js services page

### DIFF
--- a/app/services/nextjs-development/page.tsx
+++ b/app/services/nextjs-development/page.tsx
@@ -16,11 +16,13 @@ import {
 import Link from 'next/link'
 import { buildPageMetadata } from '@/lib/seo'
 
+const pageTitle = 'Hire a Next.js Developer | Remote Full-Stack | Aris Setiawan'
+
 const structuredData = {
   '@context': 'https://schema.org',
   '@type': 'WebPage',
   '@id': 'https://madebyaris.com/services/nextjs-development/#webpage',
-  name: 'Hire a Next.js Developer | Remote Full-Stack',
+  name: pageTitle,
   description:
     'Hire a Next.js developer for product builds, migrations, and performance work. Remote-friendly. 13+ years. Cursor Ambassador — AI-accelerated delivery.',
   url: 'https://madebyaris.com/services/nextjs-development',
@@ -36,6 +38,9 @@ export async function generateMetadata(): Promise<Metadata> {
 
   return {
     ...metadata,
+    title: { absolute: pageTitle },
+    openGraph: { ...metadata.openGraph, title: pageTitle },
+    twitter: { ...metadata.twitter, title: pageTitle },
     keywords: [
       'Hire Next.js Developer',
       'Next.js Developer',


### PR DESCRIPTION
Includes PR #68 — use absolute metadata title so MadeByAris + layout template do not double-brand.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use an absolute page title on the Next.js Services page to remove double-branding from the layout and keep OG/Twitter titles consistent for better SEO.

- **Bug Fixes**
  - Set `title: { absolute: 'Hire a Next.js Developer | Remote Full-Stack | Aris Setiawan' }` in `generateMetadata` to prevent a second brand suffix.
  - Synced `openGraph.title`, `twitter.title`, and structured data `name` with the same title.

<sup>Written for commit ec17ce2294759f09a688c36b0272125cbeef96ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/madebyaris/madebyaris.com/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

