### PR TITLE
Fix stale WordPress blog cache on Vercel

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,40 +1,87 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { revalidatePath, revalidateTag } from 'next/cache';
+import { NextRequest, NextResponse } from 'next/server'
+import { revalidatePath, revalidateTag } from 'next/cache'
+import { WP_CACHE_TAGS } from '@/lib/wordpress'
+
+const WP_BLOG_TAGS = [
+  WP_CACHE_TAGS.posts,
+  WP_CACHE_TAGS.categories,
+  WP_CACHE_TAGS.tags,
+] as const
+
+function revalidateWpBlogTags(revalidated: string[]) {
+  for (const tag of WP_BLOG_TAGS) {
+    revalidateTag(tag, 'max')
+    revalidated.push(`tag:${tag}`)
+  }
+}
+
+function revalidateBlogIndex(revalidated: string[]) {
+  revalidatePath('/blog')
+  if (!revalidated.includes('/blog')) {
+    revalidated.push('/blog')
+  }
+}
 
 export async function GET(request: NextRequest) {
-  const secret = request.nextUrl.searchParams.get('secret');
-  
-  // Check for secret to confirm this is a valid request
+  const secret = request.nextUrl.searchParams.get('secret')
+
   if (secret !== process.env.REVALIDATION_SECRET) {
-    return NextResponse.json({ message: 'Invalid token' }, { status: 401 });
+    return NextResponse.json({ message: 'Invalid token' }, { status: 401 })
   }
-  
+
   try {
-    // Get path to revalidate from query parameter
-    const path = request.nextUrl.searchParams.get('path') || '/';
-    
-    // Get tag to revalidate from query parameter
-    const tag = request.nextUrl.searchParams.get('tag');
-    
-    if (tag) {
-      // Next.js 16: revalidateTag now requires 2 arguments (tag, revalidationType)
-      revalidateTag(tag, 'max');
-      return NextResponse.json({ 
-        revalidated: true, 
-        message: `Tag ${tag} revalidated` 
-      });
+    const path = request.nextUrl.searchParams.get('path')
+    const tag = request.nextUrl.searchParams.get('tag')
+    const slug = request.nextUrl.searchParams.get('slug')
+
+    const revalidated: string[] = []
+
+    if (slug) {
+      const slugPath = `/blog/${slug}`
+      revalidatePath(slugPath)
+      revalidated.push(slugPath)
+      revalidateBlogIndex(revalidated)
+      revalidateWpBlogTags(revalidated)
     }
-    
-    // Otherwise, revalidate the specific path
-    revalidatePath(path);
-    return NextResponse.json({ 
-      revalidated: true, 
-      message: `Path ${path} revalidated`
-    });
+
+    if (tag) {
+      revalidateTag(tag, 'max')
+      revalidated.push(`tag:${tag}`)
+
+      if ((WP_BLOG_TAGS as readonly string[]).includes(tag)) {
+        revalidateBlogIndex(revalidated)
+      }
+    }
+
+    if (path) {
+      revalidatePath(path)
+      revalidated.push(path)
+
+      if (path === '/blog' || path.startsWith('/blog/')) {
+        revalidateWpBlogTags(revalidated)
+
+        if (path.startsWith('/blog/') && path !== '/blog') {
+          revalidateBlogIndex(revalidated)
+        }
+      }
+    }
+
+    if (revalidated.length === 0) {
+      revalidatePath('/')
+      revalidated.push('/')
+    }
+
+    const uniqueItems = [...new Set(revalidated)]
+
+    return NextResponse.json({
+      revalidated: true,
+      message: `Revalidated: ${uniqueItems.join(', ')}`,
+      items: uniqueItems,
+    })
   } catch (err) {
     return NextResponse.json(
       { message: 'Error revalidating', error: err },
       { status: 500 }
-    );
+    )
   }
 }

--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -2,10 +2,6 @@ import { Post, Project, Category, Tag } from './types'
 
 function normalizeWpApiUrl(input: string): string {
   const trimmed = input.trim().replace(/\/+$/, '')
-  // Allow either:
-  // - https://example.com
-  // - https://example.com/wp-json
-  // - https://example.com/wp-json/
   if (trimmed.endsWith('/wp-json')) return trimmed
   return `${trimmed}/wp-json`
 }
@@ -20,61 +16,25 @@ if (!RAW_WP_API_URL) {
 
 const WP_API_URL = normalizeWpApiUrl(RAW_WP_API_URL)
 
-// In-memory cache for WordPress API responses
-const cache = new Map<string, { data: unknown; timestamp: number; ttl: number }>();
+export const WP_CACHE_TAGS = {
+  posts: 'wp-posts',
+  categories: 'wp-categories',
+  tags: 'wp-tags',
+  project: 'wp-projects',
+} as const
 
-// Cache TTL in milliseconds
-const CACHE_TTL = {
-  POSTS: 5 * 60 * 1000, // 5 minutes
-  CATEGORIES: 30 * 60 * 1000, // 30 minutes
-  TAGS: 30 * 60 * 1000, // 30 minutes
-  PROJECTS: 15 * 60 * 1000, // 15 minutes
-}
+type WpEndpoint = keyof typeof WP_CACHE_TAGS
 
-// Cache utility functions
-function getCacheKey(endpoint: string, params: Record<string, string | number>): string {
-  const paramString = Object.entries(params)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([key, value]) => `${key}=${value}`)
-    .join('&');
-  return `${endpoint}${paramString ? `?${paramString}` : ''}`;
-}
+const REVALIDATE_SECONDS = {
+  POSTS: 300,
+  CATEGORIES: 1800,
+  TAGS: 1800,
+  PROJECTS: 900,
+} as const
 
-function getFromCache<T>(key: string): T | null {
-  const cached = cache.get(key);
-  if (!cached) return null;
-  
-  // Check if cache has expired
-  if (Date.now() - cached.timestamp > cached.ttl) {
-    cache.delete(key);
-    return null;
-  }
-  
-  return cached.data as T;
-}
-
-function setCache<T>(key: string, data: T, ttl: number): void {
-  cache.set(key, {
-    data,
-    timestamp: Date.now(),
-    ttl
-  });
-  
-  // Clean up old cache entries periodically
-  if (cache.size > 100) {
-    const now = Date.now();
-    for (const [cacheKey, entry] of cache.entries()) {
-      if (now - entry.timestamp > entry.ttl) {
-        cache.delete(cacheKey);
-      }
-    }
-  }
-}
-
-// Interface for posts with processed categories and tags
-interface ProcessedPost extends Omit<Post, 'categories' | 'tags'> {
-  categories: Category[];
-  tags: Tag[];
+export interface ProcessedPost extends Omit<Post, 'categories' | 'tags'> {
+  categories: Category[]
+  tags: Tag[]
 }
 
 export interface PaginationParams {
@@ -82,216 +42,181 @@ export interface PaginationParams {
   per_page?: number
   _fields?: string[]
 }
-async function fetchAPI<T>(endpoint: string, params: Record<string, string | number> = {}, ttl: number = CACHE_TTL.POSTS): Promise<T> {
-  try {
-    // Check cache first
-    const cacheKey = getCacheKey(endpoint, params);
-    const cachedData = getFromCache<T>(cacheKey);
-    
-    if (cachedData) {
-      console.log(`[Cache] Cache hit for ${endpoint}`);
-      return cachedData;
-    }
 
-    const queryString = new URLSearchParams()
-    Object.entries(params).forEach(([key, value]) => {
-      queryString.append(key, String(value))
-    })
+async function fetchAPI<T>(
+  endpoint: WpEndpoint,
+  params: Record<string, string | number> = {},
+  revalidateSeconds: number = REVALIDATE_SECONDS.POSTS
+): Promise<T> {
+  const queryString = new URLSearchParams()
+  Object.entries(params).forEach(([key, value]) => {
+    queryString.append(key, String(value))
+  })
 
-    const url = `${WP_API_URL}/wp/v2/${endpoint}/${queryString.toString() ? `?${queryString}` : ''}`
-    console.log('Fetching URL:', url) // Debug log
+  const url = `${WP_API_URL}/wp/v2/${endpoint}${queryString.toString() ? `?${queryString}` : ''}`
 
-    const response = await fetch(url, { 
-      next: { 
-        tags: [`wp-${endpoint}`], // Add cache tags for targeted revalidation
-        revalidate: Math.floor(ttl / 1000) // Convert to seconds for Next.js
-      },
-      headers: {
-        'Accept': 'application/json',
-        'Cache-Control': `s-maxage=${Math.floor(ttl / 1000)}, stale-while-revalidate=${Math.floor(ttl / 1000)}`
-      }
-    })
+  const response = await fetch(url, {
+    next: {
+      tags: [WP_CACHE_TAGS[endpoint]],
+      revalidate: revalidateSeconds,
+    },
+    headers: {
+      Accept: 'application/json',
+    },
+  })
 
-    if (!response.ok) {
-      const errorText = await response.text()
-      console.error(`API Error (${response.status}):`, errorText)
-      throw new Error(`HTTP error! status: ${response.status}`)
-    }
-
-    const data = await response.json()
-    
-    // Cache the successful response
-    setCache(cacheKey, data, ttl);
-    console.log(`[Cache] Cache set for ${endpoint}`);
-    
-    return data as T
-  } catch (error) {
-    console.error(`Failed to fetch ${endpoint}:`, error)
-    
-    // Try to return stale cache data if available
-    const cacheKey = getCacheKey(endpoint, params);
-    const staleData = cache.get(cacheKey);
-    if (staleData) {
-      console.log(`[Cache] Returning stale data for ${endpoint}`);
-      return staleData.data as T;
-    }
-    
-    throw new Error(`Failed to fetch ${endpoint}`)
+  if (!response.ok) {
+    const errorText = await response.text()
+    console.error(`API Error (${response.status}):`, errorText)
+    throw new Error(`HTTP error! status: ${response.status}`)
   }
+
+  return response.json() as Promise<T>
 }
 
-export async function getPost(slug: string): Promise<Post | null> {
+async function fetchCategoriesByIds(categoryIds: number[]): Promise<Category[]> {
+  if (categoryIds.length === 0) return []
+
+  const WP_MAX_PER_PAGE = 100
+  const batches: number[][] = []
+  for (let i = 0; i < categoryIds.length; i += WP_MAX_PER_PAGE) {
+    batches.push(categoryIds.slice(i, i + WP_MAX_PER_PAGE))
+  }
+
+  const batchResults = await Promise.all(
+    batches.map(async (batch) => {
+      const query = new URLSearchParams({
+        include: batch.join(','),
+        per_page: String(batch.length),
+      })
+      const url = `${WP_API_URL}/wp/v2/categories?${query}`
+
+      const response = await fetch(url, {
+        next: {
+          tags: [WP_CACHE_TAGS.categories],
+          revalidate: REVALIDATE_SECONDS.CATEGORIES,
+        },
+        headers: { Accept: 'application/json' },
+      })
+
+      if (!response.ok) return []
+      return response.json() as Promise<Array<{ id: number; name: string; slug: string }>>
+    })
+  )
+
+  return batchResults.flat().map((category) => ({
+    id: category.id,
+    name: category.name,
+    slug: category.slug,
+  }))
+}
+
+async function fetchTagsByIds(tagIds: number[]): Promise<Tag[]> {
+  if (tagIds.length === 0) return []
+
+  const WP_MAX_PER_PAGE = 100
+  const batches: number[][] = []
+  for (let i = 0; i < tagIds.length; i += WP_MAX_PER_PAGE) {
+    batches.push(tagIds.slice(i, i + WP_MAX_PER_PAGE))
+  }
+
+  const batchResults = await Promise.all(
+    batches.map(async (batch) => {
+      const query = new URLSearchParams({
+        include: batch.join(','),
+        per_page: String(batch.length),
+      })
+      const url = `${WP_API_URL}/wp/v2/tags?${query}`
+
+      const response = await fetch(url, {
+        next: {
+          tags: [WP_CACHE_TAGS.tags],
+          revalidate: REVALIDATE_SECONDS.TAGS,
+        },
+        headers: { Accept: 'application/json' },
+      })
+
+      if (!response.ok) return []
+      return response.json() as Promise<
+        Array<{ id: number; name: string; slug: string; count?: number }>
+      >
+    })
+  )
+
+  return batchResults.flat().map((tag) => ({
+    id: tag.id,
+    name: tag.name,
+    slug: tag.slug,
+    count: tag.count || 0,
+  }))
+}
+
+async function hydratePost(post: Post): Promise<ProcessedPost> {
+  const processedPost: ProcessedPost = {
+    ...post,
+    categories: [],
+    tags: [],
+  }
+
+  if (post.categories && Array.isArray(post.categories) && post.categories.length > 0) {
+    const categoryIds = post.categories.filter((c): c is number => typeof c === 'number')
+    processedPost.categories = await fetchCategoriesByIds(categoryIds)
+  }
+
+  if (post.tags && Array.isArray(post.tags) && post.tags.length > 0) {
+    const tagIds = post.tags.filter((t): t is number => typeof t === 'number')
+    processedPost.tags = await fetchTagsByIds(tagIds)
+  }
+
+  return processedPost
+}
+
+export async function getPost(slug: string): Promise<ProcessedPost | null> {
   try {
     const posts = await fetchAPI<Post[]>('posts', {
       slug,
       _embed: 'wp:featuredmedia,wp:term',
-      per_page: 1
-    }, CACHE_TTL.POSTS)
+      per_page: 1,
+    })
 
-    return posts[0] || null
+    const post = posts[0]
+    if (!post) return null
+
+    return hydratePost(post)
   } catch (error) {
     console.error('Failed to fetch post:', error)
     return null
   }
 }
 
-async function getCategoriesByIds(categoryIds: number[]): Promise<Category[]> {
-  if (!categoryIds || categoryIds.length === 0) return [];
-
-  const uncachedIds: number[] = [];
-  const results: (Category | null)[] = [];
-
-  for (const id of categoryIds) {
-    const cached = getFromCache<Category>(`category-${id}`);
-    if (cached) {
-      results.push(cached);
-    } else {
-      results.push(null);
-      uncachedIds.push(id);
-    }
-  }
-
-  if (uncachedIds.length > 0) {
-    try {
-      const WP_MAX_PER_PAGE = 100;
-      const batches: number[][] = [];
-      for (let i = 0; i < uncachedIds.length; i += WP_MAX_PER_PAGE) {
-        batches.push(uncachedIds.slice(i, i + WP_MAX_PER_PAGE));
-      }
-
-      const batchResults = await Promise.all(batches.map(async (batch) => {
-        const response = await fetch(
-          `${WP_API_URL}/wp/v2/categories?include=${batch.join(',')}&per_page=${batch.length}`,
-          {
-            headers: { 'Accept': 'application/json' },
-            next: { revalidate: Math.floor(CACHE_TTL.CATEGORIES / 1000) }
-          }
-        );
-        if (!response.ok) return [];
-        return response.json() as Promise<Array<{ id: number; name: string; slug: string }>>;
-      }));
-
-      const fetchedMap = new Map(
-        batchResults.flat().map(c => [c.id, { id: c.id, name: c.name, slug: c.slug }])
-      );
-
-      for (const [idx, cat] of results.entries()) {
-        if (cat === null) {
-          const id = categoryIds[idx];
-          const fresh = fetchedMap.get(id) ?? null;
-          if (fresh) setCache(`category-${id}`, fresh, CACHE_TTL.CATEGORIES);
-          results[idx] = fresh;
-        }
-      }
-    } catch (error) {
-      console.error('Failed to batch-fetch categories:', error);
-    }
-  }
-
-  return results.filter((c): c is Category => c !== null);
-}
-
-async function getTagsByIds(tagIds: number[]): Promise<Tag[]> {
-  if (!tagIds || tagIds.length === 0) return [];
-
-  const uncachedIds: number[] = [];
-  const results: (Tag | null)[] = [];
-
-  for (const id of tagIds) {
-    const cached = getFromCache<Tag>(`tag-${id}`);
-    if (cached) {
-      results.push(cached);
-    } else {
-      results.push(null);
-      uncachedIds.push(id);
-    }
-  }
-
-  if (uncachedIds.length > 0) {
-    try {
-      const WP_MAX_PER_PAGE = 100;
-      const batches: number[][] = [];
-      for (let i = 0; i < uncachedIds.length; i += WP_MAX_PER_PAGE) {
-        batches.push(uncachedIds.slice(i, i + WP_MAX_PER_PAGE));
-      }
-
-      const batchResults = await Promise.all(batches.map(async (batch) => {
-        const response = await fetch(
-          `${WP_API_URL}/wp/v2/tags?include=${batch.join(',')}&per_page=${batch.length}`,
-          {
-            headers: { 'Accept': 'application/json' },
-            next: { revalidate: Math.floor(CACHE_TTL.TAGS / 1000) }
-          }
-        );
-        if (!response.ok) return [];
-        return response.json() as Promise<Array<{ id: number; name: string; slug: string; count?: number }>>;
-      }));
-
-      const fetchedMap = new Map(
-        batchResults.flat().map(t => [t.id, { id: t.id, name: t.name, slug: t.slug, count: t.count || 0 }])
-      );
-
-      for (const [idx, tag] of results.entries()) {
-        if (tag === null) {
-          const id = tagIds[idx];
-          const fresh = fetchedMap.get(id) ?? null;
-          if (fresh) setCache(`tag-${id}`, fresh, CACHE_TTL.TAGS);
-          results[idx] = fresh;
-        }
-      }
-    } catch (error) {
-      console.error('Failed to batch-fetch tags:', error);
-    }
-  }
-
-  return results.filter((t): t is Tag => t !== null);
-}
-
-// Function to get all tags sorted by popularity (count)
 export async function getAllTags(limit: number = 10): Promise<Tag[]> {
   try {
-    const tags = await fetchAPI<Array<{ id: number; name: string; slug: string; count?: number }>>('tags', {
-      orderby: 'count',
-      order: 'desc',
-      per_page: limit
-    }, CACHE_TTL.TAGS);
-    
-    return tags.map((tag: { id: number; name: string; slug: string; count?: number }) => ({
+    const tags = await fetchAPI<Array<{ id: number; name: string; slug: string; count?: number }>>(
+      'tags',
+      {
+        orderby: 'count',
+        order: 'desc',
+        per_page: limit,
+      },
+      REVALIDATE_SECONDS.TAGS
+    )
+
+    return tags.map((tag) => ({
       id: tag.id,
       name: tag.name,
       slug: tag.slug,
-      count: tag.count || 0
-    }));
+      count: tag.count || 0,
+    }))
   } catch (error) {
-    console.error('Failed to fetch tags:', error);
-    return [];
+    console.error('Failed to fetch tags:', error)
+    return []
   }
 }
 
 export async function getPosts(params: PaginationParams = {}): Promise<ProcessedPost[]> {
   try {
     const queryParams: Record<string, string | number> = {
-      _embed: 'wp:featuredmedia'
+      _embed: 'wp:featuredmedia',
     }
 
     if (params.per_page) {
@@ -306,33 +231,8 @@ export async function getPosts(params: PaginationParams = {}): Promise<Processed
       queryParams._fields = params._fields.join(',')
     }
 
-    const posts = await fetchAPI<Post[]>('posts', queryParams, CACHE_TTL.POSTS)
-    
-    // Process posts to fetch and add full category and tag objects
-    const processedPosts = await Promise.all(posts.map(async (post) => {
-      // Create a new object with the processed data
-      const processedPost: ProcessedPost = {
-        ...post,
-        categories: [],
-        tags: []
-      };
-
-      // Fetch full category objects if we have category IDs
-      if (post.categories && Array.isArray(post.categories) && post.categories.length > 0) {
-        const categoryIds = post.categories.filter((c): c is number => typeof c === 'number')
-        processedPost.categories = await getCategoriesByIds(categoryIds);
-      }
-      
-      // Fetch full tag objects if we have tag IDs
-      if (post.tags && Array.isArray(post.tags) && post.tags.length > 0) {
-        const tagIds = post.tags.filter((t): t is number => typeof t === 'number')
-        processedPost.tags = await getTagsByIds(tagIds);
-      }
-      
-      return processedPost;
-    }));
-    
-    return processedPosts;
+    const posts = await fetchAPI<Post[]>('posts', queryParams)
+    return Promise.all(posts.map(hydratePost))
   } catch (error) {
     console.error('Failed to fetch posts:', error)
     return []
@@ -341,11 +241,15 @@ export async function getPosts(params: PaginationParams = {}): Promise<Processed
 
 export async function getProjects(params: PaginationParams = {}): Promise<Project[]> {
   try {
-    return await fetchAPI<Project[]>('project', {
-      _embed: '1',
-      per_page: params.per_page || 9,
-      page: params.page || 1
-    })
+    return await fetchAPI<Project[]>(
+      'project',
+      {
+        _embed: '1',
+        per_page: params.per_page || 9,
+        page: params.page || 1,
+      },
+      REVALIDATE_SECONDS.PROJECTS
+    )
   } catch (error) {
     console.error('Failed to fetch projects:', error)
     return []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After publishing or updating WordPress posts (categories, tags, new articles), production on Vercel continued serving stale HTML for hours. Live headers showed `x-vercel-cache: HIT` with long ages despite `s-maxage=300`.

## Root cause

The hypothesis was confirmed:

1. `lib/wordpress.ts` used a process-memory `Map` cache on top of Next.js fetch cache, so `revalidateTag` could not bust in-memory entries on warm serverless instances.
2. Category/tag lookups also used the in-memory cache without fetch tags.
3. `getPost()` returned raw category/tag IDs, so the post page tag section (which filters for objects) rendered nothing.
4. `/api/revalidate` only revalidated a single path or tag, not the full blog surface (index + slug + WP fetch tags).

## Changes

### `lib/wordpress.ts`
- Removed the in-memory `Map` cache entirely.
- All WP fetches now use Next.js fetch cache tags: `wp-posts`, `wp-categories`, `wp-tags`.
- Extracted shared `hydratePost()` used by both `getPosts()` and `getPost()`.
- `getPost()` now returns hydrated `ProcessedPost` with full category/tag objects.

### `app/api/revalidate/route.ts`
- Keeps existing `secret`, `path`, and `tag` GET params.
- Adds optional `slug` param to revalidate `/blog/[slug]`.
- Blog-related revalidation now cascades:
  - `slug` → busts slug path, `/blog`, and all WP tags
  - `path=/blog` or `/blog/*` → busts WP tags (and index for slug paths)
  - `tag=wp-posts|wp-categories|wp-tags` → also busts `/blog`

## Usage

After publishing in WordPress, call:

```
GET /api/revalidate?secret=YOUR_SECRET&slug=your-post-slug
```

Or combine params:

```
GET /api/revalidate?secret=YOUR_SECRET&path=/blog&tag=wp-posts
```

## Testing

- `pnpm lint` passes (pre-existing warnings only)
- `pnpm build` succeeds
- Dev server: `/blog/cursor-ai-pricing` renders hydrated tag links (`ai`, `ide`)
- `/api/revalidate?secret=...&slug=cursor-ai-pricing` returns revalidated paths and tags
- `/api/revalidate?secret=...&tag=wp-posts` also revalidates `/blog`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-181954c3-926f-4471-aaef-66e3b3bbf0ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-181954c3-926f-4471-aaef-66e3b3bbf0ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale WordPress blog pages on Vercel by removing the in‑memory cache and using Next.js fetch cache tags. Revalidation now evicts the blog index, slug pages, and WP data caches immediately; post pages correctly render category/tag links.

- Removes the process-memory cache in `lib/wordpress.ts`; all WP requests use cache tags: `wp-posts`, `wp-categories`, `wp-tags` (via `WP_CACHE_TAGS`).
- Adds `hydratePost()`; `getPost()` now returns `ProcessedPost` with full category/tag objects (was raw ID arrays).
- Extends `/api/revalidate` with `slug` and cascades invalidation:
  - slug → revalidate `/blog/[slug]`, `/blog`, and WP tags
  - path `/blog` or `/blog/*` → revalidate relevant WP tags (and index for slug paths)
  - WP tag revalidation also refreshes `/blog`
- Migration: If any caller relied on numeric category/tag IDs from `getPost()`, update usage to read `categories` and `tags` objects.
- After publishing in WordPress, trigger: GET `/api/revalidate?secret=...&slug=post-slug`.

<sup>Written for commit 8526846596dfad32cf6aecf0b5e6b017451c4320. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/madebyaris/madebyaris.com/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

