### PR TITLE
Fix GSC ProfilePage mainEntity and author 404 redirect

### DIFF
--- a/app/cursor-ambassador/page.tsx
+++ b/app/cursor-ambassador/page.tsx
@@ -2,16 +2,17 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { ArrowRight, ArrowUpRight, BookOpen, Users, Sparkles, ExternalLink } from 'lucide-react'
 import { CursorIcon } from '@/components/icons/cursor'
+import { buildProfilePageSchema } from '@/lib/seo'
 
 export const revalidate = 86400
 
-const structuredData = {
-  "@context": "https://schema.org",
-  "@type": "ProfilePage",
-  "name": "Cursor Ambassador | Made by Aris",
-  "description": "About Aris Setiawan as a Cursor Ambassador: community, education, and building with Cursor.",
-  "url": "https://madebyaris.com/cursor-ambassador"
-}
+const structuredData = buildProfilePageSchema({
+  name: 'Cursor Ambassador | Made by Aris',
+  description:
+    'About Aris Setiawan as a Cursor Ambassador: community, education, and building with Cursor.',
+  url: 'https://madebyaris.com/cursor-ambassador',
+  jobTitle: 'Cursor Ambassador',
+})
 
 export const metadata: Metadata = {
   title: 'Cursor Ambassador | Made by Aris',

--- a/app/minimax-ambassador/page.tsx
+++ b/app/minimax-ambassador/page.tsx
@@ -2,16 +2,17 @@ import type { Metadata } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
 import { ArrowRight, ArrowUpRight, Sparkles, Users, Lightbulb, ExternalLink } from 'lucide-react'
+import { buildProfilePageSchema } from '@/lib/seo'
 
 export const revalidate = 86400
 
-const structuredData = {
-  "@context": "https://schema.org",
-  "@type": "ProfilePage",
-  "name": "MiniMax Dev Community Expert | Made by Aris",
-  "description": "About Aris Setiawan as a MiniMax Dev Community Expert: community, education, and building with AI tools.",
-  "url": "https://madebyaris.com/minimax-ambassador"
-}
+const structuredData = buildProfilePageSchema({
+  name: 'MiniMax Dev Community Expert | Made by Aris',
+  description:
+    'About Aris Setiawan as a MiniMax Dev Community Expert: community, education, and building with AI tools.',
+  url: 'https://madebyaris.com/minimax-ambassador',
+  jobTitle: 'MiniMax Dev Community Expert',
+})
 
 export const metadata: Metadata = {
   title: 'MiniMax Dev Community Expert | Made by Aris',

--- a/lib/seo/index.ts
+++ b/lib/seo/index.ts
@@ -4,6 +4,7 @@ export {
   buildOrganizationSchema,
   buildArticleSchema,
   buildBreadcrumbSchema,
+  buildProfilePageSchema,
   buildBlogPostGraph,
 } from './schema'
 export {

--- a/lib/seo/schema.ts
+++ b/lib/seo/schema.ts
@@ -45,6 +45,28 @@ export function buildBreadcrumbSchema(
   }).jsonLd
 }
 
+export function buildProfilePageSchema(input: {
+  name: string
+  description: string
+  url: string
+  jobTitle: string
+}) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ProfilePage',
+    name: input.name,
+    description: input.description,
+    url: input.url,
+    mainEntity: {
+      '@type': 'Person',
+      name: siteConfig.author,
+      url: absoluteUrl('/about'),
+      jobTitle: input.jobTitle,
+      sameAs: [...siteConfig.sameAs],
+    },
+  }
+}
+
 export function buildBlogPostGraph(input: {
   slug: string
   headline: string

--- a/next.config.js
+++ b/next.config.js
@@ -134,6 +134,16 @@ const nextConfig = {
       destination: '/services/wordpress',
       permanent: true,
     },
+    {
+      source: '/author/madebyaris',
+      destination: '/about',
+      permanent: true,
+    },
+    {
+      source: '/author/madebyaris/',
+      destination: '/about',
+      permanent: true,
+    },
   ],
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two Google Search Console issues on madebyaris.com.

### 1. ProfilePage missing `mainEntity`

Ambassador pages (`/cursor-ambassador`, `/minimax-ambassador`) emitted ProfilePage JSON-LD without the required `mainEntity` Person field.

- Added `buildProfilePageSchema()` in `lib/seo/schema.ts` following existing SEO helpers
- Both pages now include a Person `mainEntity` with name, url, page-specific `jobTitle`, and `sameAs` from `siteConfig`
- Existing ProfilePage `name`, `description`, and `url` are unchanged

### 2. 404 author URL

`/author/madebyaris` and `/author/madebyaris/` returned 404.

- Added permanent redirects in `next.config.js` to `/about` (matches existing redirect convention)

## Verification

- `pnpm lint` passes (0 errors)
- Dev server curl checks:
  - Both ambassador pages emit ProfilePage JSON-LD with `mainEntity` Person
  - `/author/madebyaris` 308 redirects to `/about` (200)
  - `/author/madebyaris/` follows redirect chain to `/about` (200)

## Sample JSON-LD (cursor-ambassador)

```json
{
  "@context": "https://schema.org",
  "@type": "ProfilePage",
  "name": "Cursor Ambassador | Made by Aris",
  "description": "About Aris Setiawan as a Cursor Ambassador: community, education, and building with Cursor.",
  "url": "https://madebyaris.com/cursor-ambassador",
  "mainEntity": {
    "@type": "Person",
    "name": "Aris Setiawan",
    "url": "https://madebyaris.com/about",
    "jobTitle": "Cursor Ambassador",
    "sameAs": ["https://github.com/madebyaris", "https://www.linkedin.com/in/arissetia", "https://www.upwork.com/freelancers/~0117c4a4c888d9e9fe", "https://x.com/arisberikut"]
  }
}
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccc62265-a0d0-4c97-a15e-8becbac96b0b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccc62265-a0d0-4c97-a15e-8becbac96b0b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing ProfilePage `mainEntity` Person for ambassador pages and redirects the old author URL to About, clearing GSC errors. Previously the pages lacked `mainEntity` and `/author/madebyaris(/)` 404ed; now both pages include a Person, and the author URL permanently redirects to `/about`.

- Add `buildProfilePageSchema` in `lib/seo/schema.ts` (exported via `lib/seo/index.ts`) and use it in both ambassador pages. It preserves existing `name`, `description`, and `url`, and adds a Person `mainEntity` with page-specific `jobTitle` and `sameAs`.
- Add permanent redirects for `/author/madebyaris` and `/author/madebyaris/` to `/about` in next config.
- Review: View page source for both ambassador pages and confirm ProfilePage JSON-LD includes a Person `mainEntity`; curl the author paths and confirm a permanent redirect to `/about` resolves 200.

<sup>Written for commit 022521ab0eb7202a3cc8e2e7cea7ac7d8ccf8af8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/madebyaris/madebyaris.com/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

