### PR TITLE
Ship GSC profile schema, author redirect, and blog cache fix

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,40 +1,87 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { revalidatePath, revalidateTag } from 'next/cache';
+import { NextRequest, NextResponse } from 'next/server'
+import { revalidatePath, revalidateTag } from 'next/cache'
+import { WP_CACHE_TAGS } from '@/lib/wordpress'
+
+const WP_BLOG_TAGS = [
+  WP_CACHE_TAGS.posts,
+  WP_CACHE_TAGS.categories,
+  WP_CACHE_TAGS.tags,
+] as const
+
+function revalidateWpBlogTags(revalidated: string[]) {
+  for (const tag of WP_BLOG_TAGS) {
+    revalidateTag(tag, 'max')
+    revalidated.push(`tag:${tag}`)
+  }
+}
+
+function revalidateBlogIndex(revalidated: string[]) {
+  revalidatePath('/blog')
+  if (!revalidated.includes('/blog')) {
+    revalidated.push('/blog')
+  }
+}
 
 export async function GET(request: NextRequest) {
-  const secret = request.nextUrl.searchParams.get('secret');
-  
-  // Check for secret to confirm this is a valid request
+  const secret = request.nextUrl.searchParams.get('secret')
+
   if (secret !== process.env.REVALIDATION_SECRET) {
-    return NextResponse.json({ message: 'Invalid token' }, { status: 401 });
+    return NextResponse.json({ message: 'Invalid token' }, { status: 401 })
   }
-  
+
   try {
-    // Get path to revalidate from query parameter
-    const path = request.nextUrl.searchParams.get('path') || '/';
-    
-    // Get tag to revalidate from query parameter
-    const tag = request.nextUrl.searchParams.get('tag');
-    
-    if (tag) {
-      // Next.js 16: revalidateTag now requires 2 arguments (tag, revalidationType)
-      revalidateTag(tag, 'max');
-      return NextResponse.json({ 
-        revalidated: true, 
-        message: `Tag ${tag} revalidated` 
-      });
+    const path = request.nextUrl.searchParams.get('path')
+    const tag = request.nextUrl.searchParams.get('tag')
+    const slug = request.nextUrl.searchParams.get('slug')
+
+    const revalidated: string[] = []
+
+    if (slug) {
+      const slugPath = `/blog/${slug}`
+      revalidatePath(slugPath)
+      revalidated.push(slugPath)
+      revalidateBlogIndex(revalidated)
+      revalidateWpBlogTags(revalidated)
     }
-    
-    // Otherwise, revalidate the specific path
-    revalidatePath(path);
-    return NextResponse.json({ 
-      revalidated: true, 
-      message: `Path ${path} revalidated`
-    });
+
+    if (tag) {
+      revalidateTag(tag, 'max')
+      revalidated.push(`tag:${tag}`)
+
+      if ((WP_BLOG_TAGS as readonly string[]).includes(tag)) {
+        revalidateBlogIndex(revalidated)
+      }
+    }
+
+    if (path) {
+      revalidatePath(path)
+      revalidated.push(path)
+
+      if (path === '/blog' || path.startsWith('/blog/')) {
+        revalidateWpBlogTags(revalidated)
+
+        if (path.startsWith('/blog/') && path !== '/blog') {
+          revalidateBlogIndex(revalidated)
+        }
+      }
+    }
+
+    if (revalidated.length === 0) {
+      revalidatePath('/')
+      revalidated.push('/')
+    }
+
+    const uniqueItems = [...new Set(revalidated)]
+
+    return NextResponse.json({
+      revalidated: true,
+      message: `Revalidated: ${uniqueItems.join(', ')}`,
+      items: uniqueItems,
+    })
   } catch (err) {
     return NextResponse.json(
       { message: 'Error revalidating', error: err },
       { status: 500 }
-    );
+    )
   }
 }

--- a/app/cursor-ambassador/page.tsx
+++ b/app/cursor-ambassador/page.tsx
@@ -2,16 +2,17 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { ArrowRight, ArrowUpRight, BookOpen, Users, Sparkles, ExternalLink } from 'lucide-react'
 import { CursorIcon } from '@/components/icons/cursor'
+import { buildProfilePageSchema } from '@/lib/seo'
 
 export const revalidate = 86400
 
-const structuredData = {
-  "@context": "https://schema.org",
-  "@type": "ProfilePage",
-  "name": "Cursor Ambassador | Made by Aris",
-  "description": "About Aris Setiawan as a Cursor Ambassador: community, education, and building with Cursor.",
-  "url": "https://madebyaris.com/cursor-ambassador"
-}
+const structuredData = buildProfilePageSchema({
+  name: 'Cursor Ambassador | Made by Aris',
+  description:
+    'About Aris Setiawan as a Cursor Ambassador: community, education, and building with Cursor.',
+  url: 'https://madebyaris.com/cursor-ambassador',
+  jobTitle: 'Cursor Ambassador',
+})
 
 export const metadata: Metadata = {
   title: 'Cursor Ambassador | Made by Aris',

--- a/app/minimax-ambassador/page.tsx
+++ b/app/minimax-ambassador/page.tsx
@@ -2,16 +2,17 @@ import type { Metadata } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
 import { ArrowRight, ArrowUpRight, Sparkles, Users, Lightbulb, ExternalLink } from 'lucide-react'
+import { buildProfilePageSchema } from '@/lib/seo'
 
 export const revalidate = 86400
 
-const structuredData = {
-  "@context": "https://schema.org",
-  "@type": "ProfilePage",
-  "name": "MiniMax Dev Community Expert | Made by Aris",
-  "description": "About Aris Setiawan as a MiniMax Dev Community Expert: community, education, and building with AI tools.",
-  "url": "https://madebyaris.com/minimax-ambassador"
-}
+const structuredData = buildProfilePageSchema({
+  name: 'MiniMax Dev Community Expert | Made by Aris',
+  description:
+    'About Aris Setiawan as a MiniMax Dev Community Expert: community, education, and building with AI tools.',
+  url: 'https://madebyaris.com/minimax-ambassador',
+  jobTitle: 'MiniMax Dev Community Expert',
+})
 
 export const metadata: Metadata = {
   title: 'MiniMax Dev Community Expert | Made by Aris',

--- a/lib/seo/index.ts
+++ b/lib/seo/index.ts
@@ -4,6 +4,7 @@ export {
   buildOrganizationSchema,
   buildArticleSchema,
   buildBreadcrumbSchema,
+  buildProfilePageSchema,
   buildBlogPostGraph,
 } from './schema'
 export {

--- a/lib/seo/schema.ts
+++ b/lib/seo/schema.ts
@@ -45,6 +45,28 @@ export function buildBreadcrumbSchema(
   }).jsonLd
 }
 
+export function buildProfilePageSchema(input: {
+  name: string
+  description: string
+  url: string
+  jobTitle: string
+}) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ProfilePage',
+    name: input.name,
+    description: input.description,
+    url: input.url,
+    mainEntity: {
+      '@type': 'Person',
+      name: siteConfig.author,
+      url: absoluteUrl('/about'),
+      jobTitle: input.jobTitle,
+      sameAs: [...siteConfig.sameAs],
+    },
+  }
+}
+
 export function buildBlogPostGraph(input: {
   slug: string
   headline: string

--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -2,10 +2,6 @@ import { Post, Project, Category, Tag } from './types'
 
 function normalizeWpApiUrl(input: string): string {
   const trimmed = input.trim().replace(/\/+$/, '')
-  // Allow either:
-  // - https://example.com
-  // - https://example.com/wp-json
-  // - https://example.com/wp-json/
   if (trimmed.endsWith('/wp-json')) return trimmed
   return `${trimmed}/wp-json`
 }
@@ -20,61 +16,25 @@ if (!RAW_WP_API_URL) {
 
 const WP_API_URL = normalizeWpApiUrl(RAW_WP_API_URL)
 
-// In-memory cache for WordPress API responses
-const cache = new Map<string, { data: unknown; timestamp: number; ttl: number }>();
+export const WP_CACHE_TAGS = {
+  posts: 'wp-posts',
+  categories: 'wp-categories',
+  tags: 'wp-tags',
+  project: 'wp-projects',
+} as const
 
-// Cache TTL in milliseconds
-const CACHE_TTL = {
-  POSTS: 5 * 60 * 1000, // 5 minutes
-  CATEGORIES: 30 * 60 * 1000, // 30 minutes
-  TAGS: 30 * 60 * 1000, // 30 minutes
-  PROJECTS: 15 * 60 * 1000, // 15 minutes
-}
+type WpEndpoint = keyof typeof WP_CACHE_TAGS
 
-// Cache utility functions
-function getCacheKey(endpoint: string, params: Record<string, string | number>): string {
-  const paramString = Object.entries(params)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([key, value]) => `${key}=${value}`)
-    .join('&');
-  return `${endpoint}${paramString ? `?${paramString}` : ''}`;
-}
+const REVALIDATE_SECONDS = {
+  POSTS: 300,
+  CATEGORIES: 1800,
+  TAGS: 1800,
+  PROJECTS: 900,
+} as const
 
-function getFromCache<T>(key: string): T | null {
-  const cached = cache.get(key);
-  if (!cached) return null;
-  
-  // Check if cache has expired
-  if (Date.now() - cached.timestamp > cached.ttl) {
-    cache.delete(key);
-    return null;
-  }
-  
-  return cached.data as T;
-}
-
-function setCache<T>(key: string, data: T, ttl: number): void {
-  cache.set(key, {
-    data,
-    timestamp: Date.now(),
-    ttl
-  });
-  
-  // Clean up old cache entries periodically
-  if (cache.size > 100) {
-    const now = Date.now();
-    for (const [cacheKey, entry] of cache.entries()) {
-      if (now - entry.timestamp > entry.ttl) {
-        cache.delete(cacheKey);
-      }
-    }
-  }
-}
-
-// Interface for posts with processed categories and tags
-interface ProcessedPost extends Omit<Post, 'categories' | 'tags'> {
-  categories: Category[];
-  tags: Tag[];
+export interface ProcessedPost extends Omit<Post, 'categories' | 'tags'> {
+  categories: Category[]
+  tags: Tag[]
 }
 
 export interface PaginationParams {
@@ -82,216 +42,181 @@ export interface PaginationParams {
   per_page?: number
   _fields?: string[]
 }
-async function fetchAPI<T>(endpoint: string, params: Record<string, string | number> = {}, ttl: number = CACHE_TTL.POSTS): Promise<T> {
-  try {
-    // Check cache first
-    const cacheKey = getCacheKey(endpoint, params);
-    const cachedData = getFromCache<T>(cacheKey);
-    
-    if (cachedData) {
-      console.log(`[Cache] Cache hit for ${endpoint}`);
-      return cachedData;
-    }
 
-    const queryString = new URLSearchParams()
-    Object.entries(params).forEach(([key, value]) => {
-      queryString.append(key, String(value))
-    })
+async function fetchAPI<T>(
+  endpoint: WpEndpoint,
+  params: Record<string, string | number> = {},
+  revalidateSeconds: number = REVALIDATE_SECONDS.POSTS
+): Promise<T> {
+  const queryString = new URLSearchParams()
+  Object.entries(params).forEach(([key, value]) => {
+    queryString.append(key, String(value))
+  })
 
-    const url = `${WP_API_URL}/wp/v2/${endpoint}/${queryString.toString() ? `?${queryString}` : ''}`
-    console.log('Fetching URL:', url) // Debug log
+  const url = `${WP_API_URL}/wp/v2/${endpoint}${queryString.toString() ? `?${queryString}` : ''}`
 
-    const response = await fetch(url, { 
-      next: { 
-        tags: [`wp-${endpoint}`], // Add cache tags for targeted revalidation
-        revalidate: Math.floor(ttl / 1000) // Convert to seconds for Next.js
-      },
-      headers: {
-        'Accept': 'application/json',
-        'Cache-Control': `s-maxage=${Math.floor(ttl / 1000)}, stale-while-revalidate=${Math.floor(ttl / 1000)}`
-      }
-    })
+  const response = await fetch(url, {
+    next: {
+      tags: [WP_CACHE_TAGS[endpoint]],
+      revalidate: revalidateSeconds,
+    },
+    headers: {
+      Accept: 'application/json',
+    },
+  })
 
-    if (!response.ok) {
-      const errorText = await response.text()
-      console.error(`API Error (${response.status}):`, errorText)
-      throw new Error(`HTTP error! status: ${response.status}`)
-    }
-
-    const data = await response.json()
-    
-    // Cache the successful response
-    setCache(cacheKey, data, ttl);
-    console.log(`[Cache] Cache set for ${endpoint}`);
-    
-    return data as T
-  } catch (error) {
-    console.error(`Failed to fetch ${endpoint}:`, error)
-    
-    // Try to return stale cache data if available
-    const cacheKey = getCacheKey(endpoint, params);
-    const staleData = cache.get(cacheKey);
-    if (staleData) {
-      console.log(`[Cache] Returning stale data for ${endpoint}`);
-      return staleData.data as T;
-    }
-    
-    throw new Error(`Failed to fetch ${endpoint}`)
+  if (!response.ok) {
+    const errorText = await response.text()
+    console.error(`API Error (${response.status}):`, errorText)
+    throw new Error(`HTTP error! status: ${response.status}`)
   }
+
+  return response.json() as Promise<T>
 }
 
-export async function getPost(slug: string): Promise<Post | null> {
+async function fetchCategoriesByIds(categoryIds: number[]): Promise<Category[]> {
+  if (categoryIds.length === 0) return []
+
+  const WP_MAX_PER_PAGE = 100
+  const batches: number[][] = []
+  for (let i = 0; i < categoryIds.length; i += WP_MAX_PER_PAGE) {
+    batches.push(categoryIds.slice(i, i + WP_MAX_PER_PAGE))
+  }
+
+  const batchResults = await Promise.all(
+    batches.map(async (batch) => {
+      const query = new URLSearchParams({
+        include: batch.join(','),
+        per_page: String(batch.length),
+      })
+      const url = `${WP_API_URL}/wp/v2/categories?${query}`
+
+      const response = await fetch(url, {
+        next: {
+          tags: [WP_CACHE_TAGS.categories],
+          revalidate: REVALIDATE_SECONDS.CATEGORIES,
+        },
+        headers: { Accept: 'application/json' },
+      })
+
+      if (!response.ok) return []
+      return response.json() as Promise<Array<{ id: number; name: string; slug: string }>>
+    })
+  )
+
+  return batchResults.flat().map((category) => ({
+    id: category.id,
+    name: category.name,
+    slug: category.slug,
+  }))
+}
+
+async function fetchTagsByIds(tagIds: number[]): Promise<Tag[]> {
+  if (tagIds.length === 0) return []
+
+  const WP_MAX_PER_PAGE = 100
+  const batches: number[][] = []
+  for (let i = 0; i < tagIds.length; i += WP_MAX_PER_PAGE) {
+    batches.push(tagIds.slice(i, i + WP_MAX_PER_PAGE))
+  }
+
+  const batchResults = await Promise.all(
+    batches.map(async (batch) => {
+      const query = new URLSearchParams({
+        include: batch.join(','),
+        per_page: String(batch.length),
+      })
+      const url = `${WP_API_URL}/wp/v2/tags?${query}`
+
+      const response = await fetch(url, {
+        next: {
+          tags: [WP_CACHE_TAGS.tags],
+          revalidate: REVALIDATE_SECONDS.TAGS,
+        },
+        headers: { Accept: 'application/json' },
+      })
+
+      if (!response.ok) return []
+      return response.json() as Promise<
+        Array<{ id: number; name: string; slug: string; count?: number }>
+      >
+    })
+  )
+
+  return batchResults.flat().map((tag) => ({
+    id: tag.id,
+    name: tag.name,
+    slug: tag.slug,
+    count: tag.count || 0,
+  }))
+}
+
+async function hydratePost(post: Post): Promise<ProcessedPost> {
+  const processedPost: ProcessedPost = {
+    ...post,
+    categories: [],
+    tags: [],
+  }
+
+  if (post.categories && Array.isArray(post.categories) && post.categories.length > 0) {
+    const categoryIds = post.categories.filter((c): c is number => typeof c === 'number')
+    processedPost.categories = await fetchCategoriesByIds(categoryIds)
+  }
+
+  if (post.tags && Array.isArray(post.tags) && post.tags.length > 0) {
+    const tagIds = post.tags.filter((t): t is number => typeof t === 'number')
+    processedPost.tags = await fetchTagsByIds(tagIds)
+  }
+
+  return processedPost
+}
+
+export async function getPost(slug: string): Promise<ProcessedPost | null> {
   try {
     const posts = await fetchAPI<Post[]>('posts', {
       slug,
       _embed: 'wp:featuredmedia,wp:term',
-      per_page: 1
-    }, CACHE_TTL.POSTS)
+      per_page: 1,
+    })
 
-    return posts[0] || null
+    const post = posts[0]
+    if (!post) return null
+
+    return hydratePost(post)
   } catch (error) {
     console.error('Failed to fetch post:', error)
     return null
   }
 }
 
-async function getCategoriesByIds(categoryIds: number[]): Promise<Category[]> {
-  if (!categoryIds || categoryIds.length === 0) return [];
-
-  const uncachedIds: number[] = [];
-  const results: (Category | null)[] = [];
-
-  for (const id of categoryIds) {
-    const cached = getFromCache<Category>(`category-${id}`);
-    if (cached) {
-      results.push(cached);
-    } else {
-      results.push(null);
-      uncachedIds.push(id);
-    }
-  }
-
-  if (uncachedIds.length > 0) {
-    try {
-      const WP_MAX_PER_PAGE = 100;
-      const batches: number[][] = [];
-      for (let i = 0; i < uncachedIds.length; i += WP_MAX_PER_PAGE) {
-        batches.push(uncachedIds.slice(i, i + WP_MAX_PER_PAGE));
-      }
-
-      const batchResults = await Promise.all(batches.map(async (batch) => {
-        const response = await fetch(
-          `${WP_API_URL}/wp/v2/categories?include=${batch.join(',')}&per_page=${batch.length}`,
-          {
-            headers: { 'Accept': 'application/json' },
-            next: { revalidate: Math.floor(CACHE_TTL.CATEGORIES / 1000) }
-          }
-        );
-        if (!response.ok) return [];
-        return response.json() as Promise<Array<{ id: number; name: string; slug: string }>>;
-      }));
-
-      const fetchedMap = new Map(
-        batchResults.flat().map(c => [c.id, { id: c.id, name: c.name, slug: c.slug }])
-      );
-
-      for (const [idx, cat] of results.entries()) {
-        if (cat === null) {
-          const id = categoryIds[idx];
-          const fresh = fetchedMap.get(id) ?? null;
-          if (fresh) setCache(`category-${id}`, fresh, CACHE_TTL.CATEGORIES);
-          results[idx] = fresh;
-        }
-      }
-    } catch (error) {
-      console.error('Failed to batch-fetch categories:', error);
-    }
-  }
-
-  return results.filter((c): c is Category => c !== null);
-}
-
-async function getTagsByIds(tagIds: number[]): Promise<Tag[]> {
-  if (!tagIds || tagIds.length === 0) return [];
-
-  const uncachedIds: number[] = [];
-  const results: (Tag | null)[] = [];
-
-  for (const id of tagIds) {
-    const cached = getFromCache<Tag>(`tag-${id}`);
-    if (cached) {
-      results.push(cached);
-    } else {
-      results.push(null);
-      uncachedIds.push(id);
-    }
-  }
-
-  if (uncachedIds.length > 0) {
-    try {
-      const WP_MAX_PER_PAGE = 100;
-      const batches: number[][] = [];
-      for (let i = 0; i < uncachedIds.length; i += WP_MAX_PER_PAGE) {
-        batches.push(uncachedIds.slice(i, i + WP_MAX_PER_PAGE));
-      }
-
-      const batchResults = await Promise.all(batches.map(async (batch) => {
-        const response = await fetch(
-          `${WP_API_URL}/wp/v2/tags?include=${batch.join(',')}&per_page=${batch.length}`,
-          {
-            headers: { 'Accept': 'application/json' },
-            next: { revalidate: Math.floor(CACHE_TTL.TAGS / 1000) }
-          }
-        );
-        if (!response.ok) return [];
-        return response.json() as Promise<Array<{ id: number; name: string; slug: string; count?: number }>>;
-      }));
-
-      const fetchedMap = new Map(
-        batchResults.flat().map(t => [t.id, { id: t.id, name: t.name, slug: t.slug, count: t.count || 0 }])
-      );
-
-      for (const [idx, tag] of results.entries()) {
-        if (tag === null) {
-          const id = tagIds[idx];
-          const fresh = fetchedMap.get(id) ?? null;
-          if (fresh) setCache(`tag-${id}`, fresh, CACHE_TTL.TAGS);
-          results[idx] = fresh;
-        }
-      }
-    } catch (error) {
-      console.error('Failed to batch-fetch tags:', error);
-    }
-  }
-
-  return results.filter((t): t is Tag => t !== null);
-}
-
-// Function to get all tags sorted by popularity (count)
 export async function getAllTags(limit: number = 10): Promise<Tag[]> {
   try {
-    const tags = await fetchAPI<Array<{ id: number; name: string; slug: string; count?: number }>>('tags', {
-      orderby: 'count',
-      order: 'desc',
-      per_page: limit
-    }, CACHE_TTL.TAGS);
-    
-    return tags.map((tag: { id: number; name: string; slug: string; count?: number }) => ({
+    const tags = await fetchAPI<Array<{ id: number; name: string; slug: string; count?: number }>>(
+      'tags',
+      {
+        orderby: 'count',
+        order: 'desc',
+        per_page: limit,
+      },
+      REVALIDATE_SECONDS.TAGS
+    )
+
+    return tags.map((tag) => ({
       id: tag.id,
       name: tag.name,
       slug: tag.slug,
-      count: tag.count || 0
-    }));
+      count: tag.count || 0,
+    }))
   } catch (error) {
-    console.error('Failed to fetch tags:', error);
-    return [];
+    console.error('Failed to fetch tags:', error)
+    return []
   }
 }
 
 export async function getPosts(params: PaginationParams = {}): Promise<ProcessedPost[]> {
   try {
     const queryParams: Record<string, string | number> = {
-      _embed: 'wp:featuredmedia'
+      _embed: 'wp:featuredmedia',
     }
 
     if (params.per_page) {
@@ -306,33 +231,8 @@ export async function getPosts(params: PaginationParams = {}): Promise<Processed
       queryParams._fields = params._fields.join(',')
     }
 
-    const posts = await fetchAPI<Post[]>('posts', queryParams, CACHE_TTL.POSTS)
-    
-    // Process posts to fetch and add full category and tag objects
-    const processedPosts = await Promise.all(posts.map(async (post) => {
-      // Create a new object with the processed data
-      const processedPost: ProcessedPost = {
-        ...post,
-        categories: [],
-        tags: []
-      };
-
-      // Fetch full category objects if we have category IDs
-      if (post.categories && Array.isArray(post.categories) && post.categories.length > 0) {
-        const categoryIds = post.categories.filter((c): c is number => typeof c === 'number')
-        processedPost.categories = await getCategoriesByIds(categoryIds);
-      }
-      
-      // Fetch full tag objects if we have tag IDs
-      if (post.tags && Array.isArray(post.tags) && post.tags.length > 0) {
-        const tagIds = post.tags.filter((t): t is number => typeof t === 'number')
-        processedPost.tags = await getTagsByIds(tagIds);
-      }
-      
-      return processedPost;
-    }));
-    
-    return processedPosts;
+    const posts = await fetchAPI<Post[]>('posts', queryParams)
+    return Promise.all(posts.map(hydratePost))
   } catch (error) {
     console.error('Failed to fetch posts:', error)
     return []
@@ -341,11 +241,15 @@ export async function getPosts(params: PaginationParams = {}): Promise<Processed
 
 export async function getProjects(params: PaginationParams = {}): Promise<Project[]> {
   try {
-    return await fetchAPI<Project[]>('project', {
-      _embed: '1',
-      per_page: params.per_page || 9,
-      page: params.page || 1
-    })
+    return await fetchAPI<Project[]>(
+      'project',
+      {
+        _embed: '1',
+        per_page: params.per_page || 9,
+        page: params.page || 1,
+      },
+      REVALIDATE_SECONDS.PROJECTS
+    )
   } catch (error) {
     console.error('Failed to fetch projects:', error)
     return []

--- a/next.config.js
+++ b/next.config.js
@@ -134,6 +134,16 @@ const nextConfig = {
       destination: '/services/wordpress',
       permanent: true,
     },
+    {
+      source: '/author/madebyaris',
+      destination: '/about',
+      permanent: true,
+    },
+    {
+      source: '/author/madebyaris/',
+      destination: '/about',
+      permanent: true,
+    },
   ],
 }
 


### PR DESCRIPTION
Merges develop into main so production gets:
- #75 ProfilePage mainEntity + /author/madebyaris -> /about
- #74 WordPress blog cache tags / revalidate

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GSC ProfilePage schema and eliminates stale blog data by replacing the in-memory WP cache with Next.js fetch cache tags. Also redirects /author/madebyaris to /about.

- Ambassador pages now use buildProfilePageSchema to add a Person mainEntity pointing to /about. Old: ProfilePage without mainEntity. New: ProfilePage with mainEntity Person and jobTitle. Effect: resolves GSC warnings.
- WordPress client drops the process-memory Map cache. Old: cache prevented Vercel revalidation from fetching fresh data. New: rely on Next.js fetch tags (`wp-posts`, `wp-categories`, `wp-tags`, `wp-projects`) with defined revalidate seconds. Effect: revalidateTag works immediately; getPost now hydrates categories and tags like getPosts.
- Revalidation API expands behavior. Old: path/tag only, limited blog invalidation. New: supports slug for targeted post revalidation, auto-busts blog index and WP tags as needed, and returns the list of revalidated items.
- Adds permanent redirects from /author/madebyaris (with and without trailing slash) to /about to fix 404s.

- Required rollout actions:
  - If you trigger revalidation from webhooks/automation, use:
    - Revalidate a specific post: GET /api/revalidate?secret=…&slug={post-slug}
    - Bust WP caches directly: GET /api/revalidate?secret=…&tag=wp-posts|wp-categories|wp-tags
    - Revalidate blog index: GET /api/revalidate?secret=…&path=/blog

<sup>Written for commit 0c60deae705418a74e9a3630c3e8556386f5e4c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/madebyaris/madebyaris.com/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

