### PR TITLE
Ship blog listing pagination

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,56 +1,82 @@
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
+import { redirect } from 'next/navigation'
 import { BlogContent } from '@/components/blog-content'
 import { BookOpen, ArrowRight } from 'lucide-react'
 import Link from 'next/link'
-import { getAllTags, getPosts } from '@/lib/wordpress'
+import { BLOG_POSTS_PER_PAGE, getAllTags, getPostsPaginated } from '@/lib/wordpress'
 
-export const revalidate = 600;
+export const revalidate = 600
 
-// Structured Data
 const structuredData = {
-  "@context": "https://schema.org",
-  "@type": "Blog",
-  "@id": "https://madebyaris.com/blog/#webpage",
-  "name": "Web Development Insights & Tutorials",
-  "description": "Expert insights on Next.js, React, WordPress, and modern web development practices. Technical tutorials and industry best practices.",
-  "url": "https://madebyaris.com/blog",
-  "isPartOf": {
-    "@type": "WebSite",
-    "@id": "https://madebyaris.com/#website",
-    "name": "MadeByAris",
-    "url": "https://madebyaris.com"
+  '@context': 'https://schema.org',
+  '@type': 'Blog',
+  '@id': 'https://madebyaris.com/blog/#webpage',
+  name: 'Web Development Insights & Tutorials',
+  description:
+    'Expert insights on Next.js, React, WordPress, and modern web development practices. Technical tutorials and industry best practices.',
+  url: 'https://madebyaris.com/blog',
+  isPartOf: {
+    '@type': 'WebSite',
+    '@id': 'https://madebyaris.com/#website',
+    name: 'MadeByAris',
+    url: 'https://madebyaris.com',
   },
-  "author": {
-    "@type": "Person",
-    "@id": "https://madebyaris.com/#person",
-    "name": "Aris Setiawan",
-    "jobTitle": "Senior Full Stack Developer",
-    "url": "https://madebyaris.com",
-    "image": "https://madebyaris.com/aris.png"
+  author: {
+    '@type': 'Person',
+    '@id': 'https://madebyaris.com/#person',
+    name: 'Aris Setiawan',
+    jobTitle: 'Senior Full Stack Developer',
+    url: 'https://madebyaris.com',
+    image: 'https://madebyaris.com/aris.png',
   },
-  "publisher": {
-    "@type": "Organization",
-    "@id": "https://madebyaris.com/#organization",
-    "name": "MadeByAris",
-    "url": "https://madebyaris.com"
+  publisher: {
+    '@type': 'Organization',
+    '@id': 'https://madebyaris.com/#organization',
+    name: 'MadeByAris',
+    url: 'https://madebyaris.com',
   },
-  "keywords": [
-    "Web Development",
-    "Next.js",
-    "React",
-    "WordPress",
-    "TypeScript",
-    "JavaScript",
-    "Full Stack Development"
+  keywords: [
+    'Web Development',
+    'Next.js',
+    'React',
+    'WordPress',
+    'TypeScript',
+    'JavaScript',
+    'Full Stack Development',
   ],
-  "inLanguage": "en-US"
+  inLanguage: 'en-US',
 }
 
-export async function generateMetadata(): Promise<Metadata> {
+interface BlogPageProps {
+  searchParams: Promise<{ page?: string }>
+}
+
+function parseBlogPageParam(pageParam?: string): number {
+  if (!pageParam) return 1
+
+  const parsedPage = Number.parseInt(pageParam, 10)
+  if (!Number.isFinite(parsedPage)) return 1
+
+  return parsedPage
+}
+
+function getBlogCanonicalPath(currentPage: number): string {
+  return currentPage <= 1 ? '/blog' : `/blog?page=${currentPage}`
+}
+
+export async function generateMetadata({ searchParams }: BlogPageProps): Promise<Metadata> {
+  const { page: pageParam } = await searchParams
+  const currentPage = parseBlogPageParam(pageParam)
+  const canonicalPath = getBlogCanonicalPath(currentPage)
+
   return {
-    title: 'Web Development Blog | Next.js, React & WordPress Insights',
-    description: 'Expert tutorials and insights on Next.js, React, WordPress, and modern web development practices. Learn from real-world enterprise development experience.',
+    title:
+      currentPage > 1
+        ? `Web Development Blog - Page ${currentPage} | Next.js, React & WordPress Insights`
+        : 'Web Development Blog | Next.js, React & WordPress Insights',
+    description:
+      'Expert tutorials and insights on Next.js, React, WordPress, and modern web development practices. Learn from real-world enterprise development experience.',
     keywords: [
       'Web Development Blog',
       'Next.js Tutorials',
@@ -61,37 +87,63 @@ export async function generateMetadata(): Promise<Metadata> {
       'Full Stack Development',
       'Web Performance',
       'Enterprise Solutions',
-      'Development Best Practices'
+      'Development Best Practices',
     ],
     openGraph: {
-      title: 'Web Development Blog | Next.js, React & WordPress Insights',
+      title:
+        currentPage > 1
+          ? `Web Development Blog - Page ${currentPage} | Next.js, React & WordPress Insights`
+          : 'Web Development Blog | Next.js, React & WordPress Insights',
       description: 'Expert tutorials and insights on modern web development practices.',
       type: 'website',
       locale: 'en_US',
+      url: `https://madebyaris.com${canonicalPath}`,
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Web Development Blog | Next.js, React & WordPress Insights',
+      title:
+        currentPage > 1
+          ? `Web Development Blog - Page ${currentPage} | Next.js, React & WordPress Insights`
+          : 'Web Development Blog | Next.js, React & WordPress Insights',
       description: 'Expert tutorials and insights on modern web development practices.',
     },
     alternates: {
-      canonical: 'https://madebyaris.com/blog'
-    }
+      canonical: `https://madebyaris.com${canonicalPath}`,
+    },
   }
 }
 
-export default async function BlogPage() {
-  let posts: Awaited<ReturnType<typeof getPosts>> = []
-  
+export default async function BlogPage({ searchParams }: BlogPageProps) {
+  const { page: pageParam } = await searchParams
+  const requestedPage = parseBlogPageParam(pageParam)
+
+  if (requestedPage < 1 || (pageParam === '1')) {
+    redirect('/blog')
+  }
+
+  let posts: Awaited<ReturnType<typeof getPostsPaginated>>['data'] = []
+  let totalPages = 0
+
   try {
-    const [, fetchedPosts] = await Promise.all([
+    const [, paginatedPosts] = await Promise.all([
       getAllTags(6),
-      getPosts({ per_page: 12 })
+      getPostsPaginated({
+        per_page: BLOG_POSTS_PER_PAGE,
+        page: requestedPage,
+      }),
     ])
-    posts = fetchedPosts
+
+    posts = paginatedPosts.data
+    totalPages = paginatedPosts.totalPages
   } catch (error) {
     console.error('Failed to fetch data:', error)
   }
+
+  if (requestedPage > 1 && totalPages > 0 && requestedPage > totalPages) {
+    redirect('/blog')
+  }
+
+  const currentPage = requestedPage
 
   return (
     <>
@@ -100,38 +152,35 @@ export default async function BlogPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
       />
 
-      {/* Hero Section */}
       <section className="text-center pt-8 pb-16">
-        {/* Badge */}
-        <div 
+        <div
           className="inline-flex bg-white/60 rounded-full mb-8 py-1.5 pr-4 pl-3 shadow-sm backdrop-blur-sm items-center gap-2"
           style={{
             position: 'relative',
             // @ts-expect-error CSS custom properties
             '--border-gradient': 'linear-gradient(180deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0))',
-            '--border-radius-before': '9999px'
+            '--border-radius-before': '9999px',
           }}
         >
           <BookOpen className="w-4 h-4 text-orange-500" />
-          <span className="text-xs font-semibold tracking-wider uppercase text-zinc-600">Web Development Insights</span>
+          <span className="text-xs font-semibold tracking-wider uppercase text-zinc-600">
+            Web Development Insights
+          </span>
         </div>
 
-        {/* Title */}
         <h1 className="leading-[0.95] lg:text-[4rem] text-4xl font-medium text-zinc-900 tracking-tighter mb-6">
           Development
           <span className="block gradient-text font-light">Insights</span>
         </h1>
 
-        {/* Description */}
         <p className="text-base md:text-lg text-zinc-500 max-w-2xl mx-auto mb-10 leading-relaxed font-medium">
-          Expert tutorials and insights on Next.js, React, WordPress, and modern web development practices. 
-          Learn from real-world enterprise development experience.
+          Expert tutorials and insights on Next.js, React, WordPress, and modern web development
+          practices. Learn from real-world enterprise development experience.
         </p>
 
-        {/* Technology Tags */}
         <div className="flex flex-wrap justify-center gap-2">
           {['Next.js', 'React', 'WordPress', 'TypeScript'].map((tech) => (
-            <span 
+            <span
               key={tech}
               className="px-3 py-1.5 bg-zinc-100 rounded-full text-xs font-medium text-zinc-600"
             >
@@ -141,31 +190,33 @@ export default async function BlogPage() {
         </div>
       </section>
 
-      {/* Separator */}
       <div className="w-full h-px bg-gradient-to-r from-transparent via-zinc-200 to-transparent mb-12 opacity-60" />
 
-      {/* Blog Content */}
-      <Suspense fallback={
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {[...Array(6)].map((_, i) => (
-            <div key={i} className="h-[350px] animate-pulse rounded-2xl bg-zinc-100" />
-          ))}
-        </div>
-      }>
-        <BlogContent initialPosts={posts} />
+      <Suspense
+        fallback={
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {[...Array(6)].map((_, i) => (
+              <div key={i} className="h-[350px] animate-pulse rounded-2xl bg-zinc-100" />
+            ))}
+          </div>
+        }
+      >
+        <BlogContent
+          initialPosts={posts}
+          currentPage={currentPage}
+          totalPages={totalPages}
+        />
       </Suspense>
 
-      {/* Separator */}
       <div className="w-full h-px bg-gradient-to-r from-transparent via-zinc-200 to-transparent my-16 opacity-60" />
 
-      {/* CTA Section */}
       <section className="overflow-hidden min-h-[350px] shadow-zinc-900/30 bg-zinc-900 rounded-[2rem] relative shadow-2xl mb-8">
-        {/* Grid Pattern */}
-        <div 
-          className="absolute inset-0 opacity-10" 
+        <div
+          className="absolute inset-0 opacity-10"
           style={{
-            backgroundImage: 'linear-gradient(rgba(255,255,255,.05) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.05) 1px, transparent 1px)',
-            backgroundSize: '40px 40px'
+            backgroundImage:
+              'linear-gradient(rgba(255,255,255,.05) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.05) 1px, transparent 1px)',
+            backgroundSize: '40px 40px',
           }}
         />
 
@@ -178,14 +229,14 @@ export default async function BlogPage() {
           </p>
 
           <div className="flex flex-wrap justify-center gap-3">
-            <Link 
+            <Link
               href="/contact"
               className="group flex items-center gap-3 bg-white hover:bg-zinc-100 transition-all text-zinc-900 text-sm font-medium rounded-full px-6 py-3 shadow-lg hover:shadow-xl hover:-translate-y-0.5"
             >
               <span>Get in Touch</span>
               <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
             </Link>
-            <Link 
+            <Link
               href="/services"
               className="group flex items-center gap-3 bg-white/10 hover:bg-white/20 transition-all text-white text-sm font-medium rounded-full px-6 py-3"
             >

--- a/components/blog-content.tsx
+++ b/components/blog-content.tsx
@@ -6,12 +6,15 @@ import Image from 'next/image';
 import { ArrowRight, Search } from 'lucide-react';
 import type { Post, Category } from '@/lib/types';
 import { blurDataURLs } from '@/lib/utils';
+import { BlogPagination } from '@/components/blog-pagination';
 
 interface BlogContentProps {
   initialPosts: Post[];
+  currentPage: number;
+  totalPages: number;
 }
 
-export function BlogContent({ initialPosts }: BlogContentProps) {
+export function BlogContent({ initialPosts, currentPage, totalPages }: BlogContentProps) {
   const [searchQuery, setSearchQuery] = useState('');
 
   const filteredPosts = useMemo(() => {
@@ -38,6 +41,11 @@ export function BlogContent({ initialPosts }: BlogContentProps) {
             className="w-full pl-11 pr-4 py-3 rounded-full border border-zinc-200 bg-white focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500 transition-all text-sm font-medium text-zinc-900 placeholder:text-zinc-400"
           />
         </div>
+        {searchQuery ? (
+          <p className="mt-2 text-center text-xs font-medium text-zinc-500">
+            Search applies to the {totalPages > 1 ? `${initialPosts.length} articles on this page` : 'articles shown here'}.
+          </p>
+        ) : null}
       </div>
 
       {/* Posts grid - matching homepage style exactly */}
@@ -108,10 +116,16 @@ export function BlogContent({ initialPosts }: BlogContentProps) {
         <div className="col-span-full flex flex-col items-center justify-center rounded-2xl border border-zinc-200 bg-white/50 p-12 text-center">
           <p className="text-lg font-medium text-zinc-900">No articles found</p>
           <p className="mt-2 text-sm text-zinc-500">
-            Try adjusting your search query.
+            {searchQuery
+              ? 'Try adjusting your search query on this page.'
+              : 'No articles are available on this page.'}
           </p>
         </div>
       )}
+
+      {!searchQuery ? (
+        <BlogPagination currentPage={currentPage} totalPages={totalPages} />
+      ) : null}
     </div>
   );
 }

--- a/components/blog-pagination.tsx
+++ b/components/blog-pagination.tsx
@@ -1,0 +1,122 @@
+import Link from 'next/link'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+interface BlogPaginationProps {
+  currentPage: number
+  totalPages: number
+}
+
+function getVisiblePages(currentPage: number, totalPages: number): Array<number | 'ellipsis'> {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1)
+  }
+
+  const pages = new Set<number>([1, totalPages, currentPage])
+
+  if (currentPage > 1) pages.add(currentPage - 1)
+  if (currentPage < totalPages) pages.add(currentPage + 1)
+  if (currentPage <= 3) pages.add(2).add(3)
+  if (currentPage >= totalPages - 2) pages.add(totalPages - 1).add(totalPages - 2)
+
+  const sortedPages = [...pages].sort((a, b) => a - b)
+  const visiblePages: Array<number | 'ellipsis'> = []
+
+  sortedPages.forEach((page, index) => {
+    const previousPage = sortedPages[index - 1]
+    if (previousPage !== undefined && page - previousPage > 1) {
+      visiblePages.push('ellipsis')
+    }
+    visiblePages.push(page)
+  })
+
+  return visiblePages
+}
+
+function buildBlogPageHref(page: number): string {
+  return page <= 1 ? '/blog' : `/blog?page=${page}`
+}
+
+export function BlogPagination({ currentPage, totalPages }: BlogPaginationProps) {
+  if (totalPages <= 1) {
+    return null
+  }
+
+  const visiblePages = getVisiblePages(currentPage, totalPages)
+  const hasPreviousPage = currentPage > 1
+  const hasNextPage = currentPage < totalPages
+
+  return (
+    <nav
+      aria-label="Blog pagination"
+      className="mt-12 flex flex-col items-center gap-4 sm:flex-row sm:justify-between"
+    >
+      <p className="text-sm font-medium text-zinc-500">
+        Page {currentPage} of {totalPages}
+      </p>
+
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        {hasPreviousPage ? (
+          <Link
+            href={buildBlogPageHref(currentPage - 1)}
+            className="inline-flex items-center gap-1.5 rounded-full border border-zinc-200 bg-white px-4 py-2 text-sm font-medium text-zinc-700 transition-colors hover:border-orange-200 hover:bg-orange-50 hover:text-orange-600"
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Previous
+          </Link>
+        ) : (
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-zinc-100 bg-zinc-50 px-4 py-2 text-sm font-medium text-zinc-300">
+            <ChevronLeft className="h-4 w-4" />
+            Previous
+          </span>
+        )}
+
+        <div className="flex items-center gap-1">
+          {visiblePages.map((page, index) =>
+            page === 'ellipsis' ? (
+              <span
+                key={`ellipsis-${index}`}
+                className="px-2 text-sm font-medium text-zinc-400"
+                aria-hidden="true"
+              >
+                ...
+              </span>
+            ) : page === currentPage ? (
+              <span
+                key={page}
+                aria-current="page"
+                className="inline-flex min-w-10 items-center justify-center rounded-full bg-orange-500 px-3 py-2 text-sm font-semibold text-white shadow-sm"
+              >
+                {page}
+              </span>
+            ) : (
+              <Link
+                key={page}
+                href={buildBlogPageHref(page)}
+                className="inline-flex min-w-10 items-center justify-center rounded-full border border-zinc-200 bg-white px-3 py-2 text-sm font-medium text-zinc-700 transition-colors hover:border-orange-200 hover:bg-orange-50 hover:text-orange-600"
+              >
+                {page}
+              </Link>
+            )
+          )}
+        </div>
+
+        {hasNextPage ? (
+          <Link
+            href={buildBlogPageHref(currentPage + 1)}
+            className="inline-flex items-center gap-1.5 rounded-full border border-zinc-200 bg-white px-4 py-2 text-sm font-medium text-zinc-700 transition-colors hover:border-orange-200 hover:bg-orange-50 hover:text-orange-600"
+          >
+            Next
+            <ChevronRight className="h-4 w-4" />
+          </Link>
+        ) : (
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-zinc-100 bg-zinc-50 px-4 py-2 text-sm font-medium text-zinc-300">
+            Next
+            <ChevronRight className="h-4 w-4" />
+          </span>
+        )}
+      </div>
+    </nav>
+  )
+}
+
+export { buildBlogPageHref }

--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -43,19 +43,29 @@ export interface PaginationParams {
   _fields?: string[]
 }
 
-async function fetchAPI<T>(
-  endpoint: WpEndpoint,
-  params: Record<string, string | number> = {},
-  revalidateSeconds: number = REVALIDATE_SECONDS.POSTS
-): Promise<T> {
+export const BLOG_POSTS_PER_PAGE = 12
+
+export interface PaginatedResult<T> {
+  data: T[]
+  total: number
+  totalPages: number
+}
+
+function buildWpUrl(endpoint: WpEndpoint, params: Record<string, string | number> = {}): string {
   const queryString = new URLSearchParams()
   Object.entries(params).forEach(([key, value]) => {
     queryString.append(key, String(value))
   })
 
-  const url = `${WP_API_URL}/wp/v2/${endpoint}${queryString.toString() ? `?${queryString}` : ''}`
+  return `${WP_API_URL}/wp/v2/${endpoint}${queryString.toString() ? `?${queryString}` : ''}`
+}
 
-  const response = await fetch(url, {
+async function fetchWpResponse(
+  endpoint: WpEndpoint,
+  params: Record<string, string | number> = {},
+  revalidateSeconds: number = REVALIDATE_SECONDS.POSTS
+): Promise<Response> {
+  const response = await fetch(buildWpUrl(endpoint, params), {
     next: {
       tags: [WP_CACHE_TAGS[endpoint]],
       revalidate: revalidateSeconds,
@@ -71,7 +81,31 @@ async function fetchAPI<T>(
     throw new Error(`HTTP error! status: ${response.status}`)
   }
 
+  return response
+}
+
+async function fetchAPI<T>(
+  endpoint: WpEndpoint,
+  params: Record<string, string | number> = {},
+  revalidateSeconds: number = REVALIDATE_SECONDS.POSTS
+): Promise<T> {
+  const response = await fetchWpResponse(endpoint, params, revalidateSeconds)
   return response.json() as Promise<T>
+}
+
+async function fetchAPIPaginated<T>(
+  endpoint: WpEndpoint,
+  params: Record<string, string | number> = {},
+  revalidateSeconds: number = REVALIDATE_SECONDS.POSTS
+): Promise<PaginatedResult<T>> {
+  const response = await fetchWpResponse(endpoint, params, revalidateSeconds)
+  const data = (await response.json()) as T[]
+
+  return {
+    data,
+    total: Number.parseInt(response.headers.get('X-WP-Total') ?? '0', 10),
+    totalPages: Number.parseInt(response.headers.get('X-WP-TotalPages') ?? '0', 10),
+  }
 }
 
 async function fetchCategoriesByIds(categoryIds: number[]): Promise<Category[]> {
@@ -213,30 +247,64 @@ export async function getAllTags(limit: number = 10): Promise<Tag[]> {
   }
 }
 
-export async function getPosts(params: PaginationParams = {}): Promise<ProcessedPost[]> {
-  try {
-    const queryParams: Record<string, string | number> = {
-      _embed: 'wp:featuredmedia',
-    }
-
-    if (params.per_page) {
-      queryParams.per_page = params.per_page
-    }
-
-    if (params.page) {
-      queryParams.page = params.page
-    }
-
-    if (params._fields) {
-      queryParams._fields = params._fields.join(',')
-    }
-
-    const posts = await fetchAPI<Post[]>('posts', queryParams)
-    return Promise.all(posts.map(hydratePost))
-  } catch (error) {
-    console.error('Failed to fetch posts:', error)
-    return []
+function buildPostsQueryParams(params: PaginationParams = {}): Record<string, string | number> {
+  const queryParams: Record<string, string | number> = {
+    _embed: 'wp:featuredmedia',
   }
+
+  if (params.per_page) {
+    queryParams.per_page = params.per_page
+  }
+
+  if (params.page) {
+    queryParams.page = params.page
+  }
+
+  if (params._fields) {
+    queryParams._fields = params._fields.join(',')
+  }
+
+  return queryParams
+}
+
+export async function getPostsPaginated(
+  params: PaginationParams = {}
+): Promise<PaginatedResult<ProcessedPost>> {
+  try {
+    const result = await fetchAPIPaginated<Post>('posts', buildPostsQueryParams(params))
+    const posts = await Promise.all(result.data.map(hydratePost))
+
+    return {
+      data: posts,
+      total: result.total,
+      totalPages: result.totalPages,
+    }
+  } catch (error) {
+    if (params.page && params.page > 1) {
+      try {
+        const totals = await fetchAPIPaginated<Post>('posts', buildPostsQueryParams({
+          per_page: params.per_page,
+          page: 1,
+        }))
+
+        return {
+          data: [],
+          total: totals.total,
+          totalPages: totals.totalPages,
+        }
+      } catch (totalsError) {
+        console.error('Failed to fetch post totals after pagination error:', totalsError)
+      }
+    }
+
+    console.error('Failed to fetch posts:', error)
+    return { data: [], total: 0, totalPages: 0 }
+  }
+}
+
+export async function getPosts(params: PaginationParams = {}): Promise<ProcessedPost[]> {
+  const result = await getPostsPaginated(params)
+  return result.data
 }
 
 export async function getProjects(params: PaginationParams = {}): Promise<Project[]> {


### PR DESCRIPTION
## Summary
- Merge develop → main to ship blog listing pagination (PR #77).
- `/blog` now paginates 12 posts per page with Prev/Next and page numbers from WordPress totals.

## Test plan
- [ ] https://madebyaris.com/blog shows pagination when more than 12 posts
- [ ] `/blog?page=2` loads older posts
- [ ] Invalid `/blog?page=999` redirects to `/blog`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Paginated the blog listing to 12 posts per page using WordPress totals, improving load time and SEO. Previously `/blog` showed a single page; now `/blog?page=N` renders server-side with canonical URLs and redirects invalid pages to `/blog`.

- app/blog/page.tsx: reads `?page`, redirects `page<1`, `page=1`, and out-of-range; updates metadata/OG/Twitter titles and canonical per page; uses `getPostsPaginated` and `BLOG_POSTS_PER_PAGE`.
- components/blog-pagination.tsx: new pager with Previous/Next, numeric pages, and ellipses; builds `/blog` or `/blog?page=N`.
- components/blog-content.tsx: shows a note that search applies only to the current page; renders pagination only when not searching.
- lib/wordpress.ts: adds `getPostsPaginated` returning `{ data, total, totalPages }` from `X-WP-Total(Pages)`; keeps `getPosts` as a wrapper; introduces `BLOG_POSTS_PER_PAGE = 12`.

<sup>Written for commit ceb23ddc5a6d92de93f225caf1225e35dd56b93f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/madebyaris/madebyaris.com/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

