### PR TITLE
Add IndexNow integration for Bing, Yandex, and partner search engines

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ NEXT_PUBLIC_SITE_URL=https://madebyaris.com
 # Revalidation
 REVALIDATION_SECRET=your-secret-token-here
 
+# IndexNow (Bing, Yandex, Seznam, Naver, and other IndexNow partners)
+# Generate a 32+ character hex key (e.g. uuid without dashes) and host it at /{key}.txt
+INDEXNOW_KEY=
+
 # Google Search Console verification (optional)
 GOOGLE_VERIFICATION_CODE=
 

--- a/app/[keyFile]/route.ts
+++ b/app/[keyFile]/route.ts
@@ -1,0 +1,21 @@
+import { notFound } from 'next/navigation'
+import { getIndexNowKey, isIndexNowKeyFile } from '@/lib/indexnow'
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ keyFile: string }> }
+) {
+  const { keyFile } = await params
+  const key = getIndexNowKey()
+
+  if (!key || !keyFile.endsWith('.txt') || !isIndexNowKeyFile(keyFile)) {
+    notFound()
+  }
+
+  return new Response(key, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+    },
+  })
+}

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { revalidatePath, revalidateTag } from 'next/cache'
+import { notifyIndexNow, revalidatedItemsToUrls } from '@/lib/indexnow'
 import { WP_CACHE_TAGS } from '@/lib/wordpress'
 
 const WP_BLOG_TAGS = [
@@ -72,11 +73,14 @@ export async function GET(request: NextRequest) {
     }
 
     const uniqueItems = [...new Set(revalidated)]
+    const indexNowUrls = revalidatedItemsToUrls(uniqueItems)
+    const indexNow = await notifyIndexNow(indexNowUrls)
 
     return NextResponse.json({
       revalidated: true,
       message: `Revalidated: ${uniqueItems.join(', ')}`,
       items: uniqueItems,
+      indexNow,
     })
   } catch (err) {
     return NextResponse.json(

--- a/lib/indexnow.ts
+++ b/lib/indexnow.ts
@@ -1,0 +1,69 @@
+import { absoluteUrl, productionUrl } from '@/lib/seo/config'
+
+const INDEXNOW_ENDPOINT = 'https://api.indexnow.org/indexnow'
+const INDEXNOW_HOST = new URL(productionUrl).host
+
+export function getIndexNowKey(): string | undefined {
+  const key = process.env.INDEXNOW_KEY?.trim()
+  return key || undefined
+}
+
+export function isIndexNowKeyFile(keyFile: string): boolean {
+  const key = getIndexNowKey()
+  return Boolean(key && keyFile === `${key}.txt`)
+}
+
+export function revalidatedItemsToUrls(items: readonly string[]): string[] {
+  const urls = items
+    .filter((item) => !item.startsWith('tag:'))
+    .map((path) => absoluteUrl(path))
+
+  return [...new Set(urls)]
+}
+
+export type IndexNowResult = {
+  ok: boolean
+  status?: number
+  submitted?: number
+  error?: string
+}
+
+export async function notifyIndexNow(urlList: string[]): Promise<IndexNowResult> {
+  const key = getIndexNowKey()
+  if (!key) {
+    return { ok: false, error: 'IndexNow not configured' }
+  }
+
+  if (urlList.length === 0) {
+    return { ok: true, submitted: 0 }
+  }
+
+  const keyLocation = absoluteUrl(`/${key}.txt`)
+
+  try {
+    const response = await fetch(INDEXNOW_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify({
+        host: INDEXNOW_HOST,
+        key,
+        keyLocation,
+        urlList,
+      }),
+    })
+
+    if (response.ok || response.status === 202) {
+      return { ok: true, status: response.status, submitted: urlList.length }
+    }
+
+    return {
+      ok: false,
+      status: response.status,
+      error: 'IndexNow request failed',
+    }
+  } catch {
+    return { ok: false, error: 'IndexNow request failed' }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds IndexNow plumbing so madebyaris.com can notify Bing, Yandex, Seznam, Naver, and other IndexNow partners when blog content is published or updated. Google Search Console remains separate (Google does not support IndexNow).

The existing `/api/revalidate` endpoint is extended — one authenticated call both revalidates Next.js cache and pings IndexNow. No second public endpoint or publish-protocol changes.

## Changes

- **`lib/indexnow.ts`** — helpers to resolve the key, map revalidated paths to absolute URLs (skipping cache tags), and POST to `https://api.indexnow.org/indexnow`
- **`app/[keyFile]/route.ts`** — serves `/{INDEXNOW_KEY}.txt` with the key as plain-text body (404 for anything else)
- **`app/api/revalidate/route.ts`** — after successful revalidation, submits changed public URLs to IndexNow and returns an `indexNow` status object (key is never logged or returned)
- **`.env.example`** — documents `INDEXNOW_KEY`

## Vercel setup (`madebyaris-com`)

1. Generate a key (32+ hex characters, no punctuation), e.g. `uuidgen | tr -d '-' | tr '[:upper:]' '[:lower:]'`
2. In the Vercel project dashboard → **Settings** → **Environment Variables**, add:
   - **Name:** `INDEXNOW_KEY`
   - **Value:** your generated key (same value in Preview and Production)
   - **Environments:** Preview, Production
3. Redeploy so the key file route and revalidate handler pick up the variable.
4. Verify the key file is reachable: `curl https://madebyaris.com/{your-key}.txt` — body must exactly match the key.

`REVALIDATION_SECRET` must already be set on Vercel for the revalidate webhook.

## Test locally

```bash
# After setting INDEXNOW_KEY and REVALIDATION_SECRET in .env.local
curl "http://localhost:3000/api/revalidate?secret=YOUR_REVALIDATION_SECRET&slug=hire-a-next-js-developer-what-good-looks-like-in-2026"
```

Expected response includes `"indexNow": { "ok": true, "status": 202, "submitted": 2 }` (blog post + `/blog` index).

Production example (replace `YOUR_REVALIDATION_SECRET` with the value from Vercel env):

```bash
curl "https://madebyaris.com/api/revalidate?secret=YOUR_REVALIDATION_SECRET&slug=hire-a-next-js-developer-what-good-looks-like-in-2026"
```

IndexNow failures are non-blocking — revalidation still succeeds; check the `indexNow` field in the JSON response.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f92d8b5-66f0-4f7a-b340-bac5f8220688?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f92d8b5-66f0-4f7a-b340-bac5f8220688&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds IndexNow support so one authenticated call to `/api/revalidate` now revalidates cache and notifies Bing, Yandex, and other IndexNow partners. Previously it only revalidated; now it also submits changed public URLs and serves the required key at `/{INDEXNOW_KEY}.txt`, with failures non-blocking.

**Migration**
- Set `INDEXNOW_KEY` in environment variables for Preview and Production, then redeploy.
- Verify `https://madebyaris.com/{INDEXNOW_KEY}.txt` returns the exact key.
- Check the new `indexNow` field in the revalidate JSON response for submission status.

<sup>Written for commit baba866914c216028bdcd4f2a566c906b17f8700. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/madebyaris/madebyaris.com/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

