### PR TITLE
IndexNow: ping Bing and partner engines on revalidate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ NEXT_PUBLIC_SITE_URL=https://madebyaris.com
 # Revalidation
 REVALIDATION_SECRET=your-secret-token-here
 
+# IndexNow (Bing, Yandex, Seznam, Naver, and other IndexNow partners)
+# Generate a 32+ character hex key (e.g. uuid without dashes) and host it at /{key}.txt
+INDEXNOW_KEY=
+
 # Google Search Console verification (optional)
 GOOGLE_VERIFICATION_CODE=
 

--- a/app/[keyFile]/route.ts
+++ b/app/[keyFile]/route.ts
@@ -1,0 +1,21 @@
+import { notFound } from 'next/navigation'
+import { getIndexNowKey, isIndexNowKeyFile } from '@/lib/indexnow'
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ keyFile: string }> }
+) {
+  const { keyFile } = await params
+  const key = getIndexNowKey()
+
+  if (!key || !keyFile.endsWith('.txt') || !isIndexNowKeyFile(keyFile)) {
+    notFound()
+  }
+
+  return new Response(key, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+    },
+  })
+}

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { revalidatePath, revalidateTag } from 'next/cache'
+import { notifyIndexNow, revalidatedItemsToUrls } from '@/lib/indexnow'
 import { WP_CACHE_TAGS } from '@/lib/wordpress'
 
 const WP_BLOG_TAGS = [
@@ -72,11 +73,14 @@ export async function GET(request: NextRequest) {
     }
 
     const uniqueItems = [...new Set(revalidated)]
+    const indexNowUrls = revalidatedItemsToUrls(uniqueItems)
+    const indexNow = await notifyIndexNow(indexNowUrls)
 
     return NextResponse.json({
       revalidated: true,
       message: `Revalidated: ${uniqueItems.join(', ')}`,
       items: uniqueItems,
+      indexNow,
     })
   } catch (err) {
     return NextResponse.json(

--- a/lib/indexnow.ts
+++ b/lib/indexnow.ts
@@ -1,0 +1,69 @@
+import { absoluteUrl, productionUrl } from '@/lib/seo/config'
+
+const INDEXNOW_ENDPOINT = 'https://api.indexnow.org/indexnow'
+const INDEXNOW_HOST = new URL(productionUrl).host
+
+export function getIndexNowKey(): string | undefined {
+  const key = process.env.INDEXNOW_KEY?.trim()
+  return key || undefined
+}
+
+export function isIndexNowKeyFile(keyFile: string): boolean {
+  const key = getIndexNowKey()
+  return Boolean(key && keyFile === `${key}.txt`)
+}
+
+export function revalidatedItemsToUrls(items: readonly string[]): string[] {
+  const urls = items
+    .filter((item) => !item.startsWith('tag:'))
+    .map((path) => absoluteUrl(path))
+
+  return [...new Set(urls)]
+}
+
+export type IndexNowResult = {
+  ok: boolean
+  status?: number
+  submitted?: number
+  error?: string
+}
+
+export async function notifyIndexNow(urlList: string[]): Promise<IndexNowResult> {
+  const key = getIndexNowKey()
+  if (!key) {
+    return { ok: false, error: 'IndexNow not configured' }
+  }
+
+  if (urlList.length === 0) {
+    return { ok: true, submitted: 0 }
+  }
+
+  const keyLocation = absoluteUrl(`/${key}.txt`)
+
+  try {
+    const response = await fetch(INDEXNOW_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify({
+        host: INDEXNOW_HOST,
+        key,
+        keyLocation,
+        urlList,
+      }),
+    })
+
+    if (response.ok || response.status === 202) {
+      return { ok: true, status: response.status, submitted: urlList.length }
+    }
+
+    return {
+      ok: false,
+      status: response.status,
+      error: 'IndexNow request failed',
+    }
+  } catch {
+    return { ok: false, error: 'IndexNow request failed' }
+  }
+}


### PR DESCRIPTION
## Summary
- Merges #79 into production: IndexNow ping after `/api/revalidate` so new/updated URLs go to Bing, Yandex, Seznam, Naver, and engines that ride Bing.
- Google Search Console stays the Google path.

## Test plan
- [ ] `INDEXNOW_KEY` is set on Vercel Production
- [ ] After deploy, `GET /api/revalidate?secret=...&slug=hire-a-next-js-developer-what-good-looks-like-in-2026` returns `indexNow.ok: true`
- [ ] `https://madebyaris.com/{key}.txt` returns the key as plain text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds IndexNow notifications to /api/revalidate and serves the verification key at /{INDEXNOW_KEY}.txt so Bing and partner engines get new/updated URLs right after revalidation. Previously we only cleared caches; now we also submit changed public URLs and include an indexNow result in the response; if INDEXNOW_KEY is missing it’s a safe no‑op; Google verification stays as-is.

**Migration**
- Set INDEXNOW_KEY in the environment with a 32+ char hex string.
- Ensure GET /{INDEXNOW_KEY}.txt returns the key as plain text.
- Verify GET /api/revalidate?... returns indexNow.ok: true after deploy.

<sup>Written for commit dae7ea2141935d6374b3244d6474ef70ad103cca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/madebyaris/madebyaris.com/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

